### PR TITLE
Fixed more TomEE tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 env:
   - SERVER=payara-ci-managed-update,payara-ci-managed,provided
   - SERVER=wildfly,weld-decorator-bundled,bundled
-  - SERVER=tomee
-  - SERVER=openliberty
+  - SERVER=tomee,bundled
+  - SERVER=openliberty,bundled
 script: mvn clean package -P $SERVER
 

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
@@ -39,13 +39,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.ejb.EJBContext;
-import javax.enterprise.inject.spi.CDI;
 import javax.security.auth.Subject;
 import javax.security.enterprise.CallerPrincipal;
 import javax.security.jacc.PolicyContext;
 import javax.security.jacc.PolicyContextException;
 import javax.servlet.http.HttpServletRequest;
 import org.glassfish.soteria.authorization.EJB;
+import org.glassfish.soteria.authorization.JACC;
 
 public class SubjectParser {
 
@@ -436,7 +436,7 @@ public class SubjectParser {
     private Principal doGetCallerPrincipalFromPrincipals(Iterable<Principal> principals) {
         // Check for Servlet
         try {
-            return CDI.current().select(HttpServletRequest.class).get().getUserPrincipal();
+            return ((HttpServletRequest)JACC.getFromContext("javax.servlet.http.HttpServletRequest")).getUserPrincipal();
         } catch (Exception e) {
             // Not inside an HttpServletRequest
         }

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
@@ -155,12 +155,14 @@ public class CdiExtension implements Extension {
                     .types(Object.class, HttpAuthenticationMechanism.class)
                     .addToId(FormAuthenticationMechanismDefinition.class)
                     .create(e -> {
-                        return CDI.current()
-                                .select(FormAuthenticationMechanism.class)
-                                .get()
-                                .loginToContinue(
-                                    LoginToContinueAnnotationLiteral.eval(
-                                        formAuthenticationMechanismDefinition.loginToContinue()));
+                        FormAuthenticationMechanism authMethod = CDI.current()
+                        .select(FormAuthenticationMechanism.class)
+                        .get();
+
+                        authMethod.setLoginToContinue(
+                            LoginToContinueAnnotationLiteral.eval(formAuthenticationMechanismDefinition.loginToContinue()));
+
+                        return authMethod;
                     });
         });
 
@@ -174,13 +176,14 @@ public class CdiExtension implements Extension {
                     .types(Object.class, HttpAuthenticationMechanism.class)
                     .addToId(CustomFormAuthenticationMechanismDefinition.class)
                     .create(e -> {
-                        return CDI.current()
+                        CustomFormAuthenticationMechanism authMethod = CDI.current()
                                   .select(CustomFormAuthenticationMechanism.class)
-                                  .get()
-                                  .loginToContinue(
-                                      LoginToContinueAnnotationLiteral.eval(
-                                        customFormAuthenticationMechanismDefinition.loginToContinue()));
-
+                                  .get();
+                        
+                        authMethod.setLoginToContinue(
+                            LoginToContinueAnnotationLiteral.eval(customFormAuthenticationMechanismDefinition.loginToContinue()));
+                                  
+                        return authMethod;
                     });
         });
 

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
@@ -64,17 +64,13 @@ public class CustomFormAuthenticationMechanism implements HttpAuthenticationMech
             httpMessageContext.getAuthParameters().getCredential() != null;
 	}
 	
+    @Override
     public LoginToContinue getLoginToContinue() {
         return loginToContinue;
     }
 
     public void setLoginToContinue(LoginToContinue loginToContinue) {
         this.loginToContinue = loginToContinue;
-    }
-    
-    public CustomFormAuthenticationMechanism loginToContinue(LoginToContinue loginToContinue) {
-        setLoginToContinue(loginToContinue);
-        return this;
     }
 
 }

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
@@ -78,10 +78,5 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism,
     public void setLoginToContinue(LoginToContinue loginToContinue) {
         this.loginToContinue = loginToContinue;
     }
-    
-    public FormAuthenticationMechanism loginToContinue(LoginToContinue loginToContinue) {
-        setLoginToContinue(loginToContinue);
-        return this;
-    }
 
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -732,9 +732,9 @@
                                         </artifactItem>
                                         <!-- Catalina patch for JASPIC issue -->
                                         <artifactItem>
-                                            <groupId>org.omnifaces.tomcat</groupId>
+                                            <groupId>org.apache.tomcat</groupId>
                                             <artifactId>tomcat-catalina</artifactId>
-                                            <version>8.5.20</version>
+                                            <version>8.5-SNAPSHOT</version>
                                             <type>jar</type>
                                             <overWrite>false</overWrite>
                                             <destFileName>catalina.jar</destFileName>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -694,23 +694,25 @@
                                 <tomee.additionalLibs>
                                     target/jacc-provider-tomee-bridge-0.3.jar
                                     target/jacc-provider-0.3.jar
+                                    target/catalina.jar
                                 </tomee.additionalLibs>
                                 <tomee.cleanOnStartUp>false</tomee.cleanOnStartUp>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
-					<plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>copy</id>
-                                <phase>process-test-classes</phase>
+                                <id>Patch TomEE</id>
+                                <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>copy</goal>
                                 </goals>
                                 <configuration>
                                     <artifactItems>
+                                        <!-- JACC Provider -->
                                         <artifactItem>
                                             <groupId>org.omnifaces</groupId>
                                             <artifactId>jacc-provider</artifactId>
@@ -719,12 +721,23 @@
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}</outputDirectory>
                                         </artifactItem>
-										<artifactItem>
+                                        <!-- Patch some JACC issues -->
+                                        <artifactItem>
                                             <groupId>org.omnifaces</groupId>
                                             <artifactId>jacc-provider-tomee-bridge</artifactId>
                                             <version>${jacc-provider.version}</version>
                                             <type>jar</type>
                                             <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                        <!-- Catalina patch for JASPIC issue -->
+                                        <artifactItem>
+                                            <groupId>org.omnifaces.tomcat</groupId>
+                                            <artifactId>tomcat-catalina</artifactId>
+                                            <version>8.5.20</version>
+                                            <type>jar</type>
+                                            <overWrite>false</overWrite>
+                                            <destFileName>catalina.jar</destFileName>
                                             <outputDirectory>${project.build.directory}</outputDirectory>
                                         </artifactItem>
                                     </artifactItems>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -51,6 +51,8 @@
         <arquillian-payara-server-4-managed.version>1.0.Beta3</arquillian-payara-server-4-managed.version>
         <wildfly-arquillian-container-managed.version>2.1.0.Final</wildfly-arquillian-container-managed.version>
         <docker-maven-plugin.version>0.26.0</docker-maven-plugin.version>
+		
+		<jacc-provider.version>0.3</jacc-provider.version>
     </properties>
 
     <modules>
@@ -530,12 +532,45 @@
                                 <!--<tomee.serverXml>../common/src/main/resources/tomee_server.xml</tomee.serverXml>-->
                                 <tomee.conf>../common/src/main/resources/tomee</tomee.conf>
                                 <tomee.additionalLibs>
-                                    mvn:org.omnifaces:jacc-provider-tomee-bridge:0.2
-                                    mvn:org.omnifaces:jacc-provider:0.2
+                                    target/jacc-provider-tomee-bridge-0.3.jar
+                                    target/jacc-provider-0.3.jar
                                 </tomee.additionalLibs>
                                 <tomee.cleanOnStartUp>false</tomee.cleanOnStartUp>
                             </systemPropertyVariables>
                         </configuration>
+                    </plugin>
+					<plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.omnifaces</groupId>
+                                            <artifactId>jacc-provider</artifactId>
+                                            <version>${jacc-provider.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+										<artifactItem>
+                                            <groupId>org.omnifaces</groupId>
+                                            <artifactId>jacc-provider-tomee-bridge</artifactId>
+                                            <version>${jacc-provider.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -585,7 +620,7 @@
                                         <artifactItem>
                                             <groupId>org.omnifaces</groupId>
                                             <artifactId>jacc-provider-liberty-bundle</artifactId>
-                                            <version>0.2</version>
+                                            <version>${jacc-provider.version}</version>
                                             <type>jar</type>
                                             <overWrite>false</overWrite>
                                             <outputDirectory>${project.build.directory}/jacc-provider-liberty-bundle</outputDirectory>
@@ -629,7 +664,7 @@
                                         <!--  there has to be a better way... -->
                                         <echo>Configuring server</echo>
                                         <copy file="${project.build.directory}/jacc-provider-liberty-bundle/META-INF/testjacc.mf" tofile="${project.build.directory}/wlp/usr/extension/lib/features/testjacc.mf" />
-                                        <copy file="${project.build.directory}/jacc-provider-liberty-bundle-0.2.jar" tofile="${project.build.directory}/wlp/usr/extension/lib/testjacc.jar" />
+                                        <copy file="${project.build.directory}/jacc-provider-liberty-bundle-${jacc-provider.version}.jar" tofile="${project.build.directory}/wlp/usr/extension/lib/testjacc.jar" />
                                         <copy file="../common/src/main/resources/server.xml" tofile="${project.build.directory}/wlp/templates/servers/defaultServer/server.xml" failOnError="false" />
                                     </tasks>
                                 </configuration>


### PR DESCRIPTION
Current failing tests:
- app-db
- app-mem-form
- app-mem-customform
- app-custom-session

~~Both `app-mem-form` and `app-mem-customform` might be due to a Tomcat bug. Tomcat saves some caller information only when JASPIC result is `SUCCESS`:
https://github.com/apache/tomcat/blob/trunk/java/org/apache/catalina/authenticator/AuthenticatorBase.java#L798~~

~~Then, on logout, it only calls `ServerAuthModule#cleanSubject` when that data is present: https://github.com/apache/tomcat/blob/trunk/java/org/apache/catalina/authenticator/AuthenticatorBase.java#L1139~~

~~That means `ServerAuthModule#cleanSubject` is not called on logout when the authentication result was `SEND_SUCCESS`, which is the case for redirects. I'll ask Tomcat developers or open a PR to take account of the SEND_SUCCESS result.~~

Additional notes: 
* This PR incorporates #223, which was needed for the custom-principal test.
* JACC tests will fail on Windows. I use a filesystem path for the JACC context id, which is different depending on the OS. I have to change it to always be Unix like (for now).
* I made some changes in CdiExtension. "this" was returning an unproxied object, which wasn't intercepted.
* Apparently, `tomee.additionalLibs` can only download from Maven Central. I tweaked the pom a bit.