### PR TITLE
Replace CDI.current() calls by CDIUtils#getBeanReference (JNDI loookup)

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
@@ -35,7 +35,6 @@ import javax.enterprise.inject.spi.Annotated;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.BeforeBeanDiscovery;
-import javax.enterprise.inject.spi.CDI;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessBean;
 import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
@@ -160,9 +159,7 @@ public class CdiExtension implements Extension {
                     .types(Object.class, HttpAuthenticationMechanism.class)
                     .addToId(FormAuthenticationMechanismDefinition.class)
                     .create(e -> {
-                        FormAuthenticationMechanism authMethod = CDI.current()
-                        .select(FormAuthenticationMechanism.class)
-                        .get();
+                        FormAuthenticationMechanism authMethod = CdiUtils.getBeanReference(FormAuthenticationMechanism.class);
 
                         authMethod.setLoginToContinue(
                             LoginToContinueAnnotationLiteral.eval(formAuthenticationMechanismDefinition.loginToContinue()));
@@ -181,10 +178,8 @@ public class CdiExtension implements Extension {
                     .types(Object.class, HttpAuthenticationMechanism.class)
                     .addToId(CustomFormAuthenticationMechanismDefinition.class)
                     .create(e -> {
-                        CustomFormAuthenticationMechanism authMethod = CDI.current()
-                                  .select(CustomFormAuthenticationMechanism.class)
-                                  .get();
-                        
+                        CustomFormAuthenticationMechanism authMethod = CdiUtils.getBeanReference(CustomFormAuthenticationMechanism.class);
+
                         authMethod.setLoginToContinue(
                             LoginToContinueAnnotationLiteral.eval(customFormAuthenticationMechanismDefinition.loginToContinue()));
                                   

--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -38,7 +38,6 @@ import javax.el.ELProcessor;
 import javax.enterprise.inject.Intercepted;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -93,7 +92,7 @@ public class RememberMeInterceptor implements Serializable {
     
     private AuthenticationStatus validateRequest(InvocationContext invocationContext, HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws Exception {
         
-        RememberMeIdentityStore rememberMeIdentityStore = CDI.current().select(RememberMeIdentityStore.class).get();
+        RememberMeIdentityStore rememberMeIdentityStore = CdiUtils.getBeanReference(RememberMeIdentityStore.class);
         RememberMe rememberMeAnnotation = getRememberMeFromIntercepted(getElProcessor(invocationContext, httpMessageContext), invocationContext);
         
         Cookie rememberMeCookie = getCookie(request, rememberMeAnnotation.cookieName());
@@ -155,7 +154,7 @@ public class RememberMeInterceptor implements Serializable {
     
     private void cleanSubject(InvocationContext invocationContext, HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws Exception {
     
-        RememberMeIdentityStore rememberMeIdentityStore = CDI.current().select(RememberMeIdentityStore.class).get(); // TODO ADD CHECKS
+        RememberMeIdentityStore rememberMeIdentityStore = CdiUtils.getBeanReference(RememberMeIdentityStore.class); // TODO ADD CHECKS
         RememberMe rememberMeAnnotation = getRememberMeFromIntercepted(getElProcessor(invocationContext, httpMessageContext), invocationContext);
         
         Cookie rememberMeCookie = getCookie(request, rememberMeAnnotation.cookieName());

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/BasicAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/BasicAuthenticationMechanism.java
@@ -21,7 +21,6 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
 import static org.glassfish.soteria.Utils.isEmpty;
 
-import javax.enterprise.inject.spi.CDI;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
@@ -33,6 +32,8 @@ import javax.security.enterprise.identitystore.CredentialValidationResult;
 import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.glassfish.soteria.cdi.CdiUtils;
 
 
 /**
@@ -61,7 +62,7 @@ public class BasicAuthenticationMechanism implements HttpAuthenticationMechanism
 		String[] credentials = getCredentials(request);
 		if (!isEmpty(credentials)) {
 
-            IdentityStoreHandler identityStoreHandler = CDI.current().select(IdentityStoreHandler.class).get();
+            IdentityStoreHandler identityStoreHandler = CdiUtils.getBeanReference(IdentityStoreHandler.class);
 
             CredentialValidationResult result = identityStoreHandler.validate(
                     new UsernamePasswordCredential(credentials[0], new Password(credentials[1])));

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
@@ -17,7 +17,6 @@
 package org.glassfish.soteria.mechanisms;
 
 import javax.enterprise.inject.Typed;
-import javax.enterprise.inject.spi.CDI;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
@@ -28,6 +27,7 @@ import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.glassfish.soteria.cdi.CdiUtils;
 
 /**
  * Authentication mechanism that authenticates according to the Servlet spec defined FORM
@@ -48,7 +48,7 @@ public class CustomFormAuthenticationMechanism implements HttpAuthenticationMech
         
         if (hasCredential(httpMessageContext)) {
 
-            IdentityStoreHandler identityStoreHandler = CDI.current().select(IdentityStoreHandler.class).get();
+            IdentityStoreHandler identityStoreHandler = CdiUtils.getBeanReference(IdentityStoreHandler.class);
             
             return httpMessageContext.notifyContainerAboutLogin(
                     identityStoreHandler.validate(

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
@@ -19,7 +19,6 @@ package org.glassfish.soteria.mechanisms;
 import static org.glassfish.soteria.Utils.notNull;
 
 import javax.enterprise.inject.Typed;
-import javax.enterprise.inject.spi.CDI;
 import javax.security.enterprise.AuthenticationException;
 import javax.security.enterprise.AuthenticationStatus;
 import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
@@ -32,6 +31,7 @@ import javax.security.enterprise.identitystore.IdentityStoreHandler;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.glassfish.soteria.cdi.CdiUtils;
 
 /**
  * Authentication mechanism that authenticates according to the Servlet spec defined FORM
@@ -52,7 +52,7 @@ public class FormAuthenticationMechanism implements HttpAuthenticationMechanism,
 		
 	    if (isValidFormPostback(request)) {
 
-            IdentityStoreHandler identityStoreHandler = CDI.current().select(IdentityStoreHandler.class).get();
+            IdentityStoreHandler identityStoreHandler = CdiUtils.getBeanReference(IdentityStoreHandler.class);
 	        
             return httpMessageContext.notifyContainerAboutLogin(
                     identityStoreHandler.validate(

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
@@ -23,7 +23,6 @@ import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.setLastAuthenticati
 
 import java.util.Map;
 
-import javax.enterprise.inject.spi.CDI;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.message.AuthException;
@@ -39,6 +38,7 @@ import javax.security.enterprise.authentication.mechanism.http.HttpMessageContex
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.glassfish.soteria.cdi.CdiUtils;
 import org.glassfish.soteria.cdi.spi.CDIPerRequestInitializer;
 import org.glassfish.soteria.mechanisms.HttpMessageContextImpl;
 
@@ -85,8 +85,7 @@ public class HttpBridgeServerAuthModule implements ServerAuthModule {
             setLastAuthenticationStatus(msgContext.getRequest(), status);
                 
             try {
-                status = CDI.current()
-                            .select(HttpAuthenticationMechanism.class).get()
+                status = CdiUtils.getBeanReference(HttpAuthenticationMechanism.class)
                             .validateRequest(
                                 msgContext.getRequest(), 
                                 msgContext.getResponse(), 
@@ -109,8 +108,7 @@ public class HttpBridgeServerAuthModule implements ServerAuthModule {
             HttpMessageContext msgContext = new HttpMessageContextImpl(handler, messageInfo, null);
 
             try {
-                AuthenticationStatus status = CDI.current()
-                                                 .select(HttpAuthenticationMechanism.class).get()
+                AuthenticationStatus status = CdiUtils.getBeanReference(HttpAuthenticationMechanism.class)
                                                  .secureResponse(
                                                      msgContext.getRequest(), 
                                                      msgContext.getResponse(), 
@@ -138,8 +136,7 @@ public class HttpBridgeServerAuthModule implements ServerAuthModule {
         public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
             HttpMessageContext msgContext = new HttpMessageContextImpl(handler, messageInfo, subject);
             
-            CDI.current()
-               .select(HttpAuthenticationMechanism.class).get()
+            CdiUtils.getBeanReference(HttpAuthenticationMechanism.class)
                .cleanSubject(msgContext.getRequest(), msgContext.getResponse(), msgContext);
         }
 

--- a/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
@@ -25,7 +25,7 @@ import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.registerServerAuthM
 import java.util.Set;
 import java.util.logging.Logger;
 
-import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -33,6 +33,7 @@ import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
 import org.glassfish.soteria.cdi.CdiExtension;
+import org.glassfish.soteria.cdi.CdiUtils;
 import org.glassfish.soteria.cdi.spi.CDIPerRequestInitializer;
 import org.glassfish.soteria.cdi.spi.impl.LibertyCDIPerRequestInitializer;
 import org.glassfish.soteria.mechanisms.jaspic.HttpBridgeServerAuthModule;
@@ -59,11 +60,11 @@ public class SamRegistrationInstaller implements ServletContainerInitializer, Se
 
         // Obtain a reference to the CdiExtension that was used to see if
         // there's an enabled bean
-        
-        CDI<Object> cdi;
+
+        BeanManager beanManager;
         try {
-            cdi = CDI.current();
-            
+            beanManager = CdiUtils.getBeanManager();
+
             if (logger.isLoggable(INFO)) {
                 String version = getClass().getPackage().getImplementationVersion();
                 logger.log(INFO, "Initializing Soteria {0} for context ''{1}''", new Object[]{version, ctx.getContextPath()});
@@ -78,7 +79,7 @@ public class SamRegistrationInstaller implements ServletContainerInitializer, Se
             return;
         }
         
-        CdiExtension cdiExtension = cdi.select(CdiExtension.class).get();
+        CdiExtension cdiExtension = CdiUtils.getBeanReference(beanManager, CdiExtension.class);
 
         if (cdiExtension.isHttpAuthenticationMechanismFound()) {
 


### PR DESCRIPTION
In the context of an ear deployment, CDI.current() has unpredictable behaviour regarding the scope of the returned BeanManager instance (see the WELD issue below).
In this pull request, all these calls have been replaced by Cdiutils#getBeanReference, which obtains the BeanManager instance using a JNDI lookup.

I have an integration test which fails randomly without these changes. I can commit it if required.

Fixes #200
Weld issue: https://issues.jboss.org/browse/WELD-2510