### PR TITLE
Updated WildFly to 15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ env:
   - SERVER=wildfly,weld-decorator-bundled,bundled
   - SERVER=tomee,bundled
   - SERVER=openliberty,bundled
-script: mvn clean package -P $SERVER
+script: mvn clean install -P $SERVER
 

--- a/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-custom-rememberme/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-custom-rememberme/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-custom-session/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-custom-session/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-custom/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-custom/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-db/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-db/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-jaxrs/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-jaxrs/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-ldap/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-ldap/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-ldap2/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-ldap2/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-ldap3/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-ldap3/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-mem-basic-decorate/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-mem-basic-decorate/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-mem-basic/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-mem-basic/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-mem-customform/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-mem-customform/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-mem-form/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-mem-form/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-mem/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-mem/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-multiple-store-backup/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-multiple-store-backup/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-multiple-store/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-multiple-store/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-securitycontext-auth/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-securitycontext-auth/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/app-securitycontext/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/test/app-securitycontext/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,20 @@
+<!--
+    Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<jboss-deployment-structure>
+    <deployment>
+        <exclusions>
+            <module name="org.glassfish.soteria" />
+            <module name="javax.security.enterprise.api" />
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -40,8 +40,7 @@
         
         <glassfish.version>LATEST</glassfish.version>
         
-        <!-- Note: WildFly 13 has EE Security (Soteria) included, but not activated -->
-        <wildfly.version>12.0.0.Final</wildfly.version>
+        <wildfly.version>15.0.0.Final</wildfly.version>
         
         <tomee.version>7.0.4</tomee.version>
         
@@ -57,7 +56,7 @@
         <arquillian-glassfish-embedded-3.1.version>1.0.2</arquillian-glassfish-embedded-3.1.version>
         <arquillian-glassfish-remote-3.1.version>1.0.2</arquillian-glassfish-remote-3.1.version>
         <arquillian-payara-server-4-managed.version>1.0.Beta3</arquillian-payara-server-4-managed.version>
-        <wildfly-arquillian-container-managed.version>2.1.0.Final</wildfly-arquillian-container-managed.version>
+        <wildfly-arquillian-container-managed.version>2.1.1.Final</wildfly-arquillian-container-managed.version>
         <docker-maven-plugin.version>0.26.0</docker-maven-plugin.version>
 		
 		<jacc-provider.version>0.3</jacc-provider.version>
@@ -860,39 +859,6 @@
             </build>
         </profile>
 
-        <profile>
-            <id>wildfly-docker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <version>${docker-maven-plugin.version}</version>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>wildfly</alias>
-                                    <name>soteria-samples/${project.artifactId}:wildfly</name>
-                                    <build>
-                                        <maintainer>Ivar Grimstad (ivar.grimstad@gmail.com)</maintainer>
-                                        <from>jboss/wildfly:10.1.0.Final</from>
-                                        <assembly>
-                                            <basedir>/opt/jboss/wildfly/standalone/deployments/</basedir>
-                                            <descriptorRef>artifact</descriptorRef>
-                                        </assembly>
-                                    </build>
-                                    <run>
-                                        <ports>
-                                            <port>8088:8080</port>
-                                        </ports>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>payara-docker</id>
             <build>


### PR DESCRIPTION
This updates WildFly to latest version, and removes the outdated Docker profile, which I don't think is useful anymore.

Tests will only pass with `bundled` profile enabled, but I also don't see the need to test the implementation bundled with the server (that will be covered by the TCK).