### PR TITLE
Updated Soteria to use Jakarta packages

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
@@ -16,7 +17,7 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -47,7 +48,8 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
-            <scope>test</scope> <!-- Needed to implement and instantiate HttpServletRequest -->
+            <scope>test</scope>
+            <!-- Needed to implement and instantiate HttpServletRequest -->
         </dependency>
     </dependencies>
 
@@ -90,5 +92,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -27,7 +27,6 @@
 
     <artifactId>javax.security.enterprise</artifactId>
     <packaging>bundle</packaging>
-    <version>2.0.0-SNAPSHOT</version>
 
     <name>Soteria ${project.version}</name>
     <description>EE4J Compatible Implementation for Java EE Security API</description>
@@ -41,7 +40,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -58,7 +57,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
@@ -90,44 +89,6 @@
                 </configuration>
             </plugin>
         </plugins>
-        
-        <pluginManagement>
-            <plugins>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>
-                                            org.glassfish.build
-                                        </groupId>
-                                        <artifactId>
-                                            spec-version-maven-plugin
-                                        </artifactId>
-                                        <versionRange>
-                                            [1.2,)
-                                        </versionRange>
-                                        <goals>
-                                            <goal>
-                                                set-spec-properties
-                                            </goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 
 </project>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -22,11 +22,12 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.1-SNAPSHOT</version>
+       <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>javax.security.enterprise</artifactId>
     <packaging>bundle</packaging>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Soteria ${project.version}</name>
     <description>EE4J Compatible Implementation for Java EE Security API</description>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -33,24 +33,7 @@
     <description>EE4J Compatible Implementation for Java EE Security API</description>
 
     <dependencies>
-        <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
-            <version>${api_dependency_version}</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
-            <!-- Needed to implement and instantiate HttpServletRequest -->
-        </dependency>
+        
     </dependencies>
 
     <build>

--- a/impl/src/main/java/org/glassfish/soteria/DefaultService.java
+++ b/impl/src/main/java/org/glassfish/soteria/DefaultService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2018, 2020 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/impl/src/main/java/org/glassfish/soteria/SecurityContextImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/SecurityContextImpl.java
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria;
 
-import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
-import static javax.security.enterprise.AuthenticationStatus.SUCCESS;
+import static jakarta.security.enterprise.AuthenticationStatus.SEND_FAILURE;
+import static jakarta.security.enterprise.AuthenticationStatus.SUCCESS;
 import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.getLastAuthenticationStatus;
 
 import java.io.Serializable;
@@ -25,11 +25,11 @@ import java.security.Principal;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.SecurityContext;
-import javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.soteria.authorization.spi.CallerDetailsResolver;
 import org.glassfish.soteria.authorization.spi.ResourceAccessResolver;

--- a/impl/src/main/java/org/glassfish/soteria/SecurityContextImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/SecurityContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,7 @@ import java.io.Serializable;
 import java.security.Principal;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.security.enterprise.AuthenticationStatus;
 import jakarta.security.enterprise.SecurityContext;
 import jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters;

--- a/impl/src/main/java/org/glassfish/soteria/SoteriaServiceProviders.java
+++ b/impl/src/main/java/org/glassfish/soteria/SoteriaServiceProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2018, 2020 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/impl/src/main/java/org/glassfish/soteria/Utils.java
+++ b/impl/src/main/java/org/glassfish/soteria/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/Utils.java
+++ b/impl/src/main/java/org/glassfish/soteria/Utils.java
@@ -47,13 +47,13 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
-import javax.el.ELProcessor;
-import javax.interceptor.InvocationContext;
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.el.ELProcessor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.bind.DatatypeConverter;
 
 /**

--- a/impl/src/main/java/org/glassfish/soteria/WrappingCallerPrincipal.java
+++ b/impl/src/main/java/org/glassfish/soteria/WrappingCallerPrincipal.java
@@ -18,7 +18,7 @@ package org.glassfish.soteria;
 
 import java.security.Principal;
 
-import javax.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.CallerPrincipal;
 
 public class WrappingCallerPrincipal extends CallerPrincipal {
     

--- a/impl/src/main/java/org/glassfish/soteria/WrappingCallerPrincipal.java
+++ b/impl/src/main/java/org/glassfish/soteria/WrappingCallerPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/authorization/EJB.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/authorization/JACC.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/JACC.java
@@ -37,11 +37,11 @@ import java.util.Set;
 
 import javax.ejb.EJBContext;
 import javax.security.auth.Subject;
-import javax.security.jacc.EJBRoleRefPermission;
-import javax.security.jacc.PolicyContext;
-import javax.security.jacc.PolicyContextException;
-import javax.security.jacc.WebResourcePermission;
-import javax.security.jacc.WebRoleRefPermission;
+import jakarta.security.jacc.EJBRoleRefPermission;
+import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.PolicyContextException;
+import jakarta.security.jacc.WebResourcePermission;
+import jakarta.security.jacc.WebRoleRefPermission;
 
 public class JACC {
 

--- a/impl/src/main/java/org/glassfish/soteria/authorization/JACC.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/JACC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,7 @@ import jakarta.security.jacc.WebRoleRefPermission;
 public class JACC {
 
     public static Subject getSubject() {
-        return getFromContext("javax.security.auth.Subject.container");
+        return getFromContext("jakarta.security.auth.Subject.container");
     }
 
     public static boolean isCallerInRole(String role) {

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/CallerDetailsResolver.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/CallerDetailsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/ResourceAccessResolver.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/ResourceAccessResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/JaccResourceAccessResolver.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/JaccResourceAccessResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/ReflectionAndJaccCallerDetailsResolver.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/ReflectionAndJaccCallerDetailsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/ReflectionAndJaccCallerDetailsResolver.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/ReflectionAndJaccCallerDetailsResolver.java
@@ -24,7 +24,7 @@ import java.security.Principal;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
-import static javax.security.jacc.PolicyContext.getContextID;
+import static jakarta.security.jacc.PolicyContext.getContextID;
 
 public class ReflectionAndJaccCallerDetailsResolver implements CallerDetailsResolver {
 

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
@@ -40,10 +40,10 @@ import java.util.concurrent.ConcurrentMap;
 
 import javax.ejb.EJBContext;
 import javax.security.auth.Subject;
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.jacc.PolicyContext;
-import javax.security.jacc.PolicyContextException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.PolicyContextException;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.glassfish.soteria.authorization.EJB;
 import org.glassfish.soteria.authorization.JACC;
@@ -438,7 +438,7 @@ public class SubjectParser {
     private Principal doGetCallerPrincipalFromPrincipals(Iterable<Principal> principals) {
         // Check for Servlet
         try {
-            return ((HttpServletRequest)JACC.getFromContext("javax.servlet.http.HttpServletRequest")).getUserPrincipal();
+            return ((HttpServletRequest)JACC.getFromContext("jakarta.servlet.http.HttpServletRequest")).getUserPrincipal();
         } catch (Exception e) {
             // Not inside an HttpServletRequest
         }

--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
@@ -154,7 +154,7 @@ public class SubjectParser {
                 // So we're getting the principals from the Subject here. Do note that we miss the
                 // potential extra deployment roles here which may be in the principals collection we get
                 // passed in.
-                Subject subject = (Subject) PolicyContext.getContext("javax.security.auth.Subject.container");
+                Subject subject = (Subject) PolicyContext.getContext("jakarta.security.auth.Subject.container");
 
                 if (subject == null) {
                     return null;
@@ -179,7 +179,7 @@ public class SubjectParser {
         if (isLiberty || isJboss) {
 
             try {
-                Subject subject = (Subject) PolicyContext.getContext("javax.security.auth.Subject.container");
+                Subject subject = (Subject) PolicyContext.getContext("jakarta.security.auth.Subject.container");
                 if (subject == null) {
                     return emptyList();
                 }

--- a/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AnnotationELPProcessor.java
@@ -22,7 +22,7 @@ import static org.glassfish.soteria.cdi.CdiUtils.getELProcessor;
 
 import java.lang.reflect.Array;
 
-import javax.el.ELProcessor;
+import jakarta.el.ELProcessor;
 
 public class AnnotationELPProcessor {
     

--- a/impl/src/main/java/org/glassfish/soteria/cdi/AnyAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AnyAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/AnyAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AnyAnnotationLiteral.java
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria.cdi;
 
-import javax.enterprise.inject.Any;
-import javax.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.util.AnnotationLiteral;
 
 /**
  * An annotation literal for @Any.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/AutoApplySessionInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AutoApplySessionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@ import static org.glassfish.soteria.Utils.validateRequestMethod;
 import java.io.Serializable;
 import java.security.Principal;
 
-import javax.annotation.Priority;
+import jakarta.annotation.Priority;
 import javax.security.auth.callback.Callback;
 
 import jakarta.interceptor.AroundInvoke;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/AutoApplySessionInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/AutoApplySessionInterceptor.java
@@ -16,9 +16,9 @@
 
 package org.glassfish.soteria.cdi;
 
+import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+import static jakarta.security.enterprise.AuthenticationStatus.SUCCESS;
 import static java.lang.Boolean.TRUE;
-import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
-import static javax.security.enterprise.AuthenticationStatus.SUCCESS;
 import static org.glassfish.soteria.Utils.isImplementationOf;
 import static org.glassfish.soteria.Utils.validateRequestMethod;
 
@@ -26,15 +26,15 @@ import java.io.Serializable;
 import java.security.Principal;
 
 import javax.annotation.Priority;
-import javax.el.ELProcessor;
-import javax.interceptor.AroundInvoke;
-import javax.interceptor.Interceptor;
-import javax.interceptor.InvocationContext;
 import javax.security.auth.callback.Callback;
-import javax.security.auth.message.callback.CallerPrincipalCallback;
-import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.servlet.http.HttpServletRequest;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.security.auth.message.callback.CallerPrincipalCallback;
+import jakarta.security.enterprise.authentication.mechanism.http.AutoApplySession;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
 
 @Interceptor
 @AutoApplySession
@@ -65,7 +65,7 @@ public class AutoApplySessionInterceptor implements Serializable {
             Object outcome = invocationContext.proceed();
             
             if (SUCCESS.equals(outcome)) {
-                httpMessageContext.getMessageInfo().getMap().put("javax.servlet.http.registerSession", TRUE.toString());
+                httpMessageContext.getMessageInfo().getMap().put("jakarta.servlet.http.registerSession", TRUE.toString());
             }
             
             return outcome;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/BasicAuthenticationMechanismDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/BasicAuthenticationMechanismDefinitionAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/BasicAuthenticationMechanismDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/BasicAuthenticationMechanismDefinitionAnnotationLiteral.java
@@ -19,8 +19,8 @@ package org.glassfish.soteria.cdi;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalImmediate;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
 
 /**
  * An annotation literal for <code>@BasicAuthenticationMechanismDefinition</code>.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiDecorator.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiDecorator.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiDecorator.java
@@ -25,13 +25,13 @@ import java.lang.reflect.Type;
 import java.util.Set;
 import java.util.function.BiFunction;
 
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.AnnotatedField;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.Decorator;
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.AnnotatedField;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Decorator;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 
 // WIP - Builder for dynanic decorators. May not be needed and/or replaced by
 // CDI 2.0 bean builder

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiExtension.java
@@ -28,26 +28,26 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.AfterBeanDiscovery;
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.BeforeBeanDiscovery;
-import javax.enterprise.inject.spi.Extension;
-import javax.enterprise.inject.spi.ProcessBean;
-import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
-import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.CustomFormAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
-import javax.security.enterprise.authentication.mechanism.http.RememberMe;
-import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessBean;
+import jakarta.security.enterprise.authentication.mechanism.http.AutoApplySession;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.CustomFormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;
+import jakarta.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 
 import org.glassfish.soteria.SecurityContextImpl;
 import org.glassfish.soteria.SoteriaServiceProviders;
@@ -282,7 +282,7 @@ public class CdiExtension implements Extension {
         for (Class<? extends Annotation> annotation : annotations) {
             // Check if the class is not an interceptor, and is not a valid class to be intercepted.
             if (annotated.isAnnotationPresent(annotation)
-                    && !annotated.isAnnotationPresent(javax.interceptor.Interceptor.class)
+                    && !annotated.isAnnotationPresent(jakarta.interceptor.Interceptor.class)
                     && !HttpAuthenticationMechanism.class.isAssignableFrom(beanClass)) {
                 LOGGER.log(Level.WARNING, "Only classes implementing {0} may be annotated with {1}. {2} is annotated, but the interceptor won't take effect on it.", new Object[]{
                     HttpAuthenticationMechanism.class.getName(),

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiProducer.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiProducer.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiProducer.java
@@ -27,11 +27,11 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
-import javax.enterprise.context.Dependent;
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.InjectionPoint;
-import javax.enterprise.inject.spi.PassivationCapable;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
 
 // May be replaced by CDI 2.0 bean builder API when ready.
 // See http://weld.cdi-spec.org/news/2015/02/25/weld-300Alpha5/#_bean_builder_api

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiUtils.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiUtils.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiUtils.java
@@ -31,11 +31,11 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 
-import javax.el.ELProcessor;
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.el.ELProcessor;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DatabaseIdentityStoreDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DatabaseIdentityStoreDefinitionAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DatabaseIdentityStoreDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DatabaseIdentityStoreDefinitionAnnotationLiteral.java
@@ -21,10 +21,10 @@ import static org.glassfish.soteria.cdi.AnnotationELPProcessor.emptyIfImmediate;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalImmediate;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
-import javax.security.enterprise.identitystore.PasswordHash;
-import javax.security.enterprise.identitystore.IdentityStore.ValidationType;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
+import jakarta.security.enterprise.identitystore.PasswordHash;
+import jakarta.security.enterprise.identitystore.IdentityStore.ValidationType;
 
 /**
  * An annotation literal for <code>@DatabaseIdentityStoreDefinition</code>.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DefaultAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DefaultAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DefaultAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DefaultAnnotationLiteral.java
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria.cdi;
 
-import javax.enterprise.inject.Default;
-import javax.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.util.AnnotationLiteral;
 
 /**
  * An annotation literal for @Default.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DefaultIdentityStoreHandler.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DefaultIdentityStoreHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/DefaultIdentityStoreHandler.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/DefaultIdentityStoreHandler.java
@@ -16,20 +16,20 @@
 
 package org.glassfish.soteria.cdi;
 
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.INVALID;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.INVALID;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
 import static org.glassfish.soteria.cdi.CdiUtils.getBeanReferencesByType;
 
 import java.security.AccessController;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/FormAuthenticationMechanismDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/FormAuthenticationMechanismDefinitionAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/FormAuthenticationMechanismDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/FormAuthenticationMechanismDefinitionAnnotationLiteral.java
@@ -17,9 +17,9 @@
 package org.glassfish.soteria.cdi;
 
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
 
 /**
  * An annotation literal for <code>@FormAuthenticationMechanismDefinition</code>.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LdapIdentityStoreDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LdapIdentityStoreDefinitionAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LdapIdentityStoreDefinitionAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LdapIdentityStoreDefinitionAnnotationLiteral.java
@@ -18,9 +18,9 @@ package org.glassfish.soteria.cdi;
 
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.security.enterprise.identitystore.IdentityStore.ValidationType;
-import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.security.enterprise.identitystore.IdentityStore.ValidationType;
+import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 
 /**
  * An annotation literal for <code>@LdapIdentityStoreDefinition</code>.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueAnnotationLiteral.java
@@ -20,8 +20,8 @@ import static org.glassfish.soteria.cdi.AnnotationELPProcessor.emptyIfImmediate;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalImmediate;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
 
 /**
  * An annotation literal for <code>@LoginToContinue</code>.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueInterceptor.java
@@ -17,7 +17,7 @@
 package org.glassfish.soteria.cdi;
 
 import static java.lang.Boolean.TRUE;
-import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 import static org.glassfish.soteria.Utils.getBaseURL;
 import static org.glassfish.soteria.Utils.getParam;
 import static org.glassfish.soteria.Utils.isEmpty;
@@ -32,20 +32,20 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Priority;
-import javax.enterprise.inject.Intercepted;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
-import javax.interceptor.AroundInvoke;
-import javax.interceptor.Interceptor;
-import javax.interceptor.InvocationContext;
-import javax.security.auth.message.AuthException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.glassfish.soteria.mechanisms.LoginToContinueHolder;
 import org.glassfish.soteria.servlet.AuthenticationData;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/LoginToContinueInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,7 +31,7 @@ import java.lang.annotation.Annotation;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Priority;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.inject.Intercepted;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeAnnotationLiteral.java
@@ -20,9 +20,9 @@ import static org.glassfish.soteria.cdi.AnnotationELPProcessor.emptyIfImmediate;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalELExpression;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalImmediate;
 
-import javax.el.ELProcessor;
-import javax.enterprise.util.AnnotationLiteral;
-import javax.security.enterprise.authentication.mechanism.http.RememberMe;
+import jakarta.el.ELProcessor;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;
 
 /**
  * An annotation literal for <code>@RememberMe</code>.

--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeAnnotationLiteral.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria.cdi;
 
-import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.Utils.cleanSubjectMethod;
 import static org.glassfish.soteria.Utils.getParam;
 import static org.glassfish.soteria.Utils.isImplementationOf;
@@ -34,23 +34,23 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Priority;
-import javax.el.ELProcessor;
-import javax.enterprise.inject.Intercepted;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
-import javax.interceptor.AroundInvoke;
-import javax.interceptor.Interceptor;
-import javax.interceptor.InvocationContext;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.authentication.mechanism.http.RememberMe;
-import javax.security.enterprise.credential.RememberMeCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.RememberMeIdentityStore;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.el.ELProcessor;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;
+import jakarta.security.enterprise.credential.RememberMeCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.RememberMeIdentityStore;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Interceptor
 @RememberMe

--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@ import java.lang.annotation.Annotation;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Priority;
+import jakarta.annotation.Priority;
 import jakarta.el.ELProcessor;
 import jakarta.enterprise.inject.Intercepted;
 import jakarta.enterprise.inject.spi.Bean;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/BeanDecorator.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/BeanDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2018, 2020 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/BeanDecorator.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/BeanDecorator.java
@@ -16,8 +16,8 @@
  */
 package org.glassfish.soteria.cdi.spi;
 
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 
 /**
  * Implementations of this interface should apply all CDI interceptors in the application

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/CDIPerRequestInitializer.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/CDIPerRequestInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/CDIPerRequestInitializer.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/CDIPerRequestInitializer.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.soteria.cdi.spi;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface CDIPerRequestInitializer {
 

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/DefaultBeanDecorator.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/DefaultBeanDecorator.java
@@ -16,8 +16,8 @@
  */
 package org.glassfish.soteria.cdi.spi.impl;
 
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.glassfish.soteria.DefaultService;
 import org.glassfish.soteria.cdi.spi.BeanDecorator;

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/DefaultBeanDecorator.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/DefaultBeanDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2018, 2020 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/LibertyCDIPerRequestInitializer.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/LibertyCDIPerRequestInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/LibertyCDIPerRequestInitializer.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/spi/impl/LibertyCDIPerRequestInitializer.java
@@ -16,9 +16,9 @@
 
 package org.glassfish.soteria.cdi.spi.impl;
 
-import javax.el.ELProcessor;
-import javax.servlet.ServletRequestEvent;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.el.ELProcessor;
+import jakarta.servlet.ServletRequestEvent;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.glassfish.soteria.cdi.spi.CDIPerRequestInitializer;
 

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/DatabaseIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/DatabaseIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/DatabaseIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/DatabaseIdentityStore.java
@@ -22,8 +22,8 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.toMap;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 import static org.glassfish.soteria.cdi.AnnotationELPProcessor.evalImmediate;
 import static org.glassfish.soteria.cdi.CdiUtils.getBeanReference;
 import static org.glassfish.soteria.cdi.CdiUtils.jndiLookup;
@@ -38,14 +38,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStorePermission;
-import javax.security.enterprise.identitystore.PasswordHash;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStorePermission;
+import jakarta.security.enterprise.identitystore.PasswordHash;
 import javax.sql.DataSource;
 
 public class DatabaseIdentityStore implements IdentityStore {

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/EmbeddedIdentityStore.java
@@ -21,19 +21,19 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.toMap;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStorePermission;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStorePermission;
 
 import org.glassfish.soteria.identitystores.annotation.Credentials;
 import org.glassfish.soteria.identitystores.annotation.EmbeddedIdentityStoreDefinition;

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreConfigurationException.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreException.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreRuntimeException.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/LdapIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/LdapIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/LdapIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/LdapIdentityStore.java
@@ -30,12 +30,12 @@ import javax.naming.directory.SearchResult;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.LdapName;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStorePermission;
-import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStorePermission;
+import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 import java.util.*;
 
 import static java.lang.String.format;
@@ -44,9 +44,9 @@ import static java.util.Collections.*;
 import static javax.naming.Context.*;
 import static javax.naming.directory.SearchControls.ONELEVEL_SCOPE;
 import static javax.naming.directory.SearchControls.SUBTREE_SCOPE;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.enterprise.identitystore.LdapIdentityStoreDefinition.LdapSearchScope;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition.LdapSearchScope;
 
 public class LdapIdentityStore implements IdentityStore {
 

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/annotation/Credentials.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/annotation/Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/annotation/EmbeddedIdentityStoreDefinition.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/annotation/EmbeddedIdentityStoreDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/annotation/EmbeddedIdentityStoreDefinition.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/annotation/EmbeddedIdentityStoreDefinition.java
@@ -18,14 +18,14 @@ package org.glassfish.soteria.identitystores.annotation;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStore.ValidationType;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStore.ValidationType;
 
 /**
  * Annotation used to define a container provided {@link IdentityStore} that stores

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/hash/PasswordHashCompare.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/hash/PasswordHashCompare.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/hash/Pbkdf2PasswordHashImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/hash/Pbkdf2PasswordHashImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/hash/Pbkdf2PasswordHashImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/hash/Pbkdf2PasswordHashImpl.java
@@ -28,8 +28,8 @@ import java.util.Set;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
-import javax.enterprise.context.Dependent;
-import javax.security.enterprise.identitystore.Pbkdf2PasswordHash;
+import jakarta.enterprise.context.Dependent;
+import jakarta.security.enterprise.identitystore.Pbkdf2PasswordHash;
 
 @Dependent
 public class Pbkdf2PasswordHashImpl implements Pbkdf2PasswordHash {

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/BasicAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/BasicAuthenticationMechanism.java
@@ -17,21 +17,21 @@
 package org.glassfish.soteria.mechanisms;
 
 import static java.lang.String.format;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
 import static org.glassfish.soteria.Utils.isEmpty;
 
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.soteria.cdi.CdiUtils;
 

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/BasicAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/BasicAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
@@ -16,16 +16,16 @@
 
 package org.glassfish.soteria.mechanisms;
 
-import javax.enterprise.inject.Typed;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.inject.Typed;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.AutoApplySession;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.soteria.cdi.CdiUtils;
 

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/CustomFormAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/FormAuthenticationMechanism.java
@@ -18,18 +18,18 @@ package org.glassfish.soteria.mechanisms;
 
 import static org.glassfish.soteria.Utils.notNull;
 
-import javax.enterprise.inject.Typed;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.inject.Typed;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.AutoApplySession;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.soteria.cdi.CdiUtils;
 

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -68,81 +68,51 @@ public class HttpMessageContextImpl implements HttpMessageContext {
         }
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#isProtected()
-     */
     @Override
     public boolean isProtected() {
         return Jaspic.isProtectedResource(messageInfo);
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#isAuthenticationRequest()
-     */
     @Override
     public boolean isAuthenticationRequest() {
         return Jaspic.isAuthenticationRequest(getRequest());
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#isRegisterSession()
-     */
     @Override
     public boolean isRegisterSession() {
         return Jaspic.isRegisterSession(messageInfo);
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#setRegisterSession(java.lang.String, java.util.Set)
-     */
     @Override
     public void setRegisterSession(String username, Set<String> groups) {
         Jaspic.setRegisterSession(messageInfo, username, groups);
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#cleanClientSubject()
-     */
     @Override
     public void cleanClientSubject() {
         Jaspic.cleanSubject(clientSubject);
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#getAuthParameters()
-     */
     @Override
     public AuthenticationParameters getAuthParameters() {
         return authParameters;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#getHandler()
-     */
     @Override
     public CallbackHandler getHandler() {
         return handler;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#getMessageInfo()
-     */
     @Override
     public MessageInfo getMessageInfo() {
         return messageInfo;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#getClientSubject()
-     */
     @Override
     public Subject getClientSubject() {
         return clientSubject;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#getRequest()
-     */
     @Override
     public HttpServletRequest getRequest() {
         return (HttpServletRequest) messageInfo.getRequestMessage();
@@ -159,9 +129,6 @@ public class HttpMessageContextImpl implements HttpMessageContext {
         return this;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#getResponse()
-     */
     @Override
     public HttpServletResponse getResponse() {
         return (HttpServletResponse) messageInfo.getResponseMessage();
@@ -192,9 +159,6 @@ public class HttpMessageContextImpl implements HttpMessageContext {
         return SEND_CONTINUE;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#responseUnAuthorized()
-     */
     @Override
     public AuthenticationStatus responseUnauthorized() {
         try {
@@ -206,9 +170,6 @@ public class HttpMessageContextImpl implements HttpMessageContext {
         return SEND_FAILURE;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#responseNotFound()
-     */
     @Override
     public AuthenticationStatus responseNotFound() {
         try {
@@ -220,9 +181,6 @@ public class HttpMessageContextImpl implements HttpMessageContext {
         return SEND_FAILURE;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#notifyContainerAboutLogin(java.lang.String, java.util.Set)
-     */
     @Override
     public AuthenticationStatus notifyContainerAboutLogin(String callerName, Set<String> groups) {
         NameHolderPrincipal nameHolder = null;
@@ -268,9 +226,6 @@ public class HttpMessageContextImpl implements HttpMessageContext {
         return SUCCESS;
     }
 
-    /* (non-Javadoc)
-     * @see javax.security.authenticationmechanism.http.HttpMessageContext#doNothing()
-     */
     @Override
     public AuthenticationStatus doNothing() {
         this.callerPrincipal = null;

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java
@@ -16,13 +16,13 @@
 
 package org.glassfish.soteria.mechanisms;
 
-import static javax.security.enterprise.AuthenticationStatus.NOT_DONE;
-import static javax.security.enterprise.AuthenticationStatus.SEND_CONTINUE;
-import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
-import static javax.security.enterprise.AuthenticationStatus.SUCCESS;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static jakarta.security.enterprise.AuthenticationStatus.NOT_DONE;
+import static jakarta.security.enterprise.AuthenticationStatus.SEND_CONTINUE;
+import static jakarta.security.enterprise.AuthenticationStatus.SEND_FAILURE;
+import static jakarta.security.enterprise.AuthenticationStatus.SUCCESS;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -30,15 +30,15 @@ import java.util.Set;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.MessageInfo;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.soteria.Utils;
 import org.glassfish.soteria.mechanisms.jaspic.Jaspic;

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/LoginToContinueHolder.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/LoginToContinueHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/LoginToContinueHolder.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/LoginToContinueHolder.java
@@ -17,7 +17,7 @@
 package org.glassfish.soteria.mechanisms;
 
 
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
 
 public interface LoginToContinueHolder {
 

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultAuthConfigProvider.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultAuthConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultAuthConfigProvider.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultAuthConfigProvider.java
@@ -19,13 +19,13 @@ package org.glassfish.soteria.mechanisms.jaspic;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.AuthException;
-import javax.security.auth.message.config.AuthConfigFactory;
-import javax.security.auth.message.config.AuthConfigProvider;
-import javax.security.auth.message.config.ClientAuthConfig;
-import javax.security.auth.message.config.ServerAuthConfig;
-import javax.security.auth.message.config.ServerAuthContext;
-import javax.security.auth.message.module.ServerAuthModule;
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.config.AuthConfigFactory;
+import jakarta.security.auth.message.config.AuthConfigProvider;
+import jakarta.security.auth.message.config.ClientAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
 
 /**
  * This class functions as a kind of factory-factory for {@link ServerAuthConfig} instances, which are by themselves factories

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthConfig.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthConfig.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthConfig.java
@@ -20,11 +20,11 @@ import java.util.Map;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.AuthException;
-import javax.security.auth.message.MessageInfo;
-import javax.security.auth.message.config.ServerAuthConfig;
-import javax.security.auth.message.config.ServerAuthContext;
-import javax.security.auth.message.module.ServerAuthModule;
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
 
 /**
  * This class functions as a kind of factory for {@link ServerAuthContext} instances, which are delegates for the actual

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthContext.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthContext.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/DefaultServerAuthContext.java
@@ -20,12 +20,12 @@ import java.util.Collections;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.AuthException;
-import javax.security.auth.message.AuthStatus;
-import javax.security.auth.message.MessageInfo;
-import javax.security.auth.message.ServerAuth;
-import javax.security.auth.message.config.ServerAuthContext;
-import javax.security.auth.message.module.ServerAuthModule;
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.AuthStatus;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.ServerAuth;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
 
 /**
  * The Server Authentication Context is an extra (required) indirection between the Application Server and the actual Server

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/HttpBridgeServerAuthModule.java
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria.mechanisms.jaspic;
 
-import static javax.security.enterprise.AuthenticationStatus.NOT_DONE;
-import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
+import static jakarta.security.enterprise.AuthenticationStatus.NOT_DONE;
+import static jakarta.security.enterprise.AuthenticationStatus.SEND_FAILURE;
 import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.fromAuthenticationStatus;
 import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.setLastAuthenticationStatus;
 
@@ -25,18 +25,18 @@ import java.util.Map;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.AuthException;
-import javax.security.auth.message.AuthStatus;
-import javax.security.auth.message.MessageInfo;
-import javax.security.auth.message.MessagePolicy;
-import javax.security.auth.message.config.ServerAuthContext;
-import javax.security.auth.message.module.ServerAuthModule;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.AuthStatus;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.MessagePolicy;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.soteria.cdi.CdiUtils;
 import org.glassfish.soteria.cdi.spi.CDIPerRequestInitializer;

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/Jaspic.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/Jaspic.java
@@ -26,22 +26,22 @@ import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Set;
 
-import javax.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.AuthenticationStatus;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.auth.message.AuthStatus;
-import javax.security.auth.message.MessageInfo;
-import javax.security.auth.message.callback.CallerPrincipalCallback;
-import javax.security.auth.message.callback.GroupPrincipalCallback;
-import javax.security.auth.message.config.AuthConfigFactory;
-import javax.security.auth.message.module.ServerAuthModule;
-import javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.auth.message.AuthStatus;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.callback.CallerPrincipalCallback;
+import jakarta.security.auth.message.callback.GroupPrincipalCallback;
+import jakarta.security.auth.message.config.AuthConfigFactory;
+import jakarta.security.auth.message.module.ServerAuthModule;
+import jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * A set of utility methods for using the JASPIC API
@@ -68,8 +68,8 @@ public final class Jaspic {
 	// Key in the MessageInfo Map that when present AND set to true indicated a protected resource is being accessed.
 	// When the resource is not protected, GlassFish omits the key altogether. WebSphere does insert the key and sets
 	// it to false.
-	private static final String IS_MANDATORY = "javax.security.auth.message.MessagePolicy.isMandatory";
-	private static final String REGISTER_SESSION = "javax.servlet.http.registerSession";
+	private static final String IS_MANDATORY = "jakarta.security.auth.message.MessagePolicy.isMandatory";
+	private static final String REGISTER_SESSION = "jakarta.servlet.http.registerSession";
 
 	private Jaspic() {}
 	
@@ -138,7 +138,7 @@ public final class Jaspic {
 	
 	@SuppressWarnings("unchecked")
 	public static void setRegisterSession(MessageInfo messageInfo, String username, Set<String> roles) {
-		messageInfo.getMap().put("javax.servlet.http.registerSession", TRUE.toString());
+		messageInfo.getMap().put("jakarta.servlet.http.registerSession", TRUE.toString());
 		
 		HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
 		request.setAttribute(LOGGEDIN_USERNAME, username);

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/Jaspic.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/jaspic/Jaspic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/servlet/AuthenticationData.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/AuthenticationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/servlet/CookieHandler.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/CookieHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/servlet/CookieHandler.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/CookieHandler.java
@@ -16,9 +16,9 @@
 
 package org.glassfish.soteria.servlet;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.glassfish.soteria.Utils;
 

--- a/impl/src/main/java/org/glassfish/soteria/servlet/HttpServletRequestDelegator.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/HttpServletRequestDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/servlet/HttpServletRequestDelegator.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/HttpServletRequestDelegator.java
@@ -32,9 +32,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 
 
 /**

--- a/impl/src/main/java/org/glassfish/soteria/servlet/RequestData.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/RequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/servlet/RequestData.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/RequestData.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 
 /**

--- a/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
@@ -25,12 +25,12 @@ import static org.glassfish.soteria.mechanisms.jaspic.Jaspic.registerServerAuthM
 import java.util.Set;
 import java.util.logging.Logger;
 
-import javax.enterprise.inject.spi.BeanManager;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.ServletException;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.ServletException;
 
 import org.glassfish.soteria.cdi.CdiExtension;
 import org.glassfish.soteria.cdi.CdiUtils;

--- a/impl/src/test/java/org/glassfish/soteria/identitystores/hash/Pbkdf2PasswordHashImplTest.java
+++ b/impl/src/test/java/org/glassfish/soteria/identitystores/hash/Pbkdf2PasswordHashImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/impl/src/test/java/org/glassfish/soteria/servlet/RequestDataSerializableTest.java
+++ b/impl/src/test/java/org/glassfish/soteria/servlet/RequestDataSerializableTest.java
@@ -30,21 +30,21 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.security.enterprise.CallerPrincipal;
-import javax.servlet.AsyncContext;
-import javax.servlet.DispatcherType;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpUpgradeHandler;
-import javax.servlet.http.Part;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
 
 import org.junit.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
@@ -16,24 +17,22 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
     </parent>
 
-    <description>Security Soteria - the Reference Implementation of JSR 375</description>
-
     <groupId>org.glassfish.soteria</groupId>
     <artifactId>parent</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <description>Security Soteria - the Reference Implementation of JSR 375</description>
     <inceptionYear>2015</inceptionYear>
-
     <licenses>
         <license>
             <name>EPL 2.0</name>
@@ -66,6 +65,13 @@
         <module>test</module>
     </modules>
 
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-ee4j/soteria.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-ee4j/soteria.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/soteria</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
         <api_dependency_version>1.0</api_dependency_version>
 
@@ -76,13 +82,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/soteria.git</connection>
-        <developerConnection>scm:git:https://github.com/eclipse-ee4j/soteria.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/soteria</url>
-        <tag>HEAD</tag>
-    </scm>
-   
     <dependencies>
         <dependency>
             <groupId>javax</groupId>
@@ -91,7 +90,6 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
 
     <build>
         <pluginManagement>
@@ -121,7 +119,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
         <plugins>
             <!-- Sets minimal Maven version to 3.5.4 -->
             <plugin>
@@ -167,7 +164,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>only-eclipse</id>
@@ -224,5 +221,4 @@
             </build>
         </profile>
     </profiles>
-    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
     </parent>
 
     <description>Security Soteria - the Reference Implementation of JSR 375</description>
 
     <groupId>org.glassfish.soteria</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2015</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     </scm>
 
     <properties>
-        <api_dependency_version>1.0</api_dependency_version>
+        <api_dependency_version>2.0.0-RC1</api_dependency_version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -84,11 +84,59 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>7.0</version>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <version>${api_dependency_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0-M1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <version>2.0.0-RC1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <version>4.0.0-RC1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>3.0.0-M1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
+            <version>2.0.0-RC1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.authorization</groupId>
+            <artifactId>jakarta.authorization-api</artifactId>
+            <version>2.0.0-RC1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ejb</groupId>
+            <artifactId>javax.ejb-api</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
+        </dependency>
+        
     </dependencies>
 
     <build>
@@ -206,6 +254,19 @@
                                                 <goals>
                                                     <goal>copyright</goal>
                                                     <goal>check</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                        <pluginExecution>
+                                        <pluginExecutionFilter>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-dependency-plugin</artifactId>
+                                                <versionRange>[3.1.0,)</versionRange>
+                                                <goals>
+                                                    <goal>unpack</goal>
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-
-        <copyright-plugin.version>1.44</copyright-plugin.version>
-        <source-plugin.version>3.0.1</source-plugin.version>
-        <javadoc-plugin.version>3.0.1</javadoc-plugin.version>
-        <enforcer-plugin-version>3.0.0-M2</enforcer-plugin-version>
-        <gpg-plugin-version>1.6</gpg-plugin-version>
     </properties>
 
     <scm>
@@ -105,7 +99,7 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>${copyright-plugin.version}</version>
+                    <version>2.3</version>
                     <configuration>
                         <scm>git</scm>
                         <scmOnly>true</scmOnly>
@@ -129,13 +123,33 @@
         </pluginManagement>
 
         <plugins>
-
+            <!-- Sets minimal Maven version to 3.5.4 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.4</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin> 
             <!-- Configure the jar with the sources (or rather, convince Maven that
                 we want sources at all) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>${source-plugin.version}</version>
+                <version>3.0.1</version>
             </plugin>
 
             <!-- Configure the jar with the javadoc (or rather, convince Maven that
@@ -143,7 +157,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${javadoc-plugin.version}</version>
+                <version>3.0.1</version>
                 <configuration>
                     <javadocVersion>1.8</javadocVersion>
                     <notimestamp>true</notimestamp>
@@ -151,17 +165,64 @@
                     <doctitle>${project.name} ${project.version}</doctitle>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${enforcer-plugin-version}</version>
-            </plugin>               
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-gpg-plugin</artifactId>
-               <version>${gpg-plugin-version}</version>
-            </plugin>
         </plugins>
-
     </build>
+    
+    <profiles>
+        <profile>
+            <id>only-eclipse</id>
+            <activation>
+                <property>
+                    <name>m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <!-- This plugin's configuration is used to store Eclipse m2e settings only. It has no influence 
+                            on the Maven build itself. -->
+                        <plugin>
+                            <groupId>org.eclipse.m2e</groupId>
+                            <artifactId>lifecycle-mapping</artifactId>
+                            <version>1.0.0</version>
+                            <configuration>
+                                <lifecycleMappingMetadata>
+                                    <pluginExecutions>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>org.glassfish.build</groupId>
+                                                <artifactId>spec-version-maven-plugin</artifactId>
+                                                <versionRange>[1.2,)</versionRange>
+                                                <goals>
+                                                    <goal>set-spec-properties</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>org.glassfish.copyright</groupId>
+                                                <artifactId>glassfish-copyright-maven-plugin</artifactId>
+                                                <versionRange>[1.2,)</versionRange>
+                                                <goals>
+                                                    <goal>copyright</goal>
+                                                    <goal>check</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                    </pluginExecutions>
+                                </lifecycleMappingMetadata>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
+    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.0.0-RC1</version>
+        </dependency>
+        <dependency>
             <groupId>jakarta.security.auth.message</groupId>
             <artifactId>jakarta.security.auth.message-api</artifactId>
             <version>2.0.0-RC1</version>

--- a/spi/bean-decorator/pom.xml
+++ b/spi/bean-decorator/pom.xml
@@ -34,6 +34,9 @@
    <name>Soteria SPI : Bean Decorator</name>
 
    <modules>
+    
+        <!--  DISABLE UNTIL A WELD VERSION USING JAKARTA APIS IS RELEASED
         <module>weld</module>
+        -->
     </modules>
 </project>

--- a/spi/bean-decorator/pom.xml
+++ b/spi/bean-decorator/pom.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2015, 2018 Payara and/or its affiliates and others. 
+    Copyright (c) 2015, 2020 Payara and/or its affiliates and others. 
     All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/spi/bean-decorator/pom.xml
+++ b/spi/bean-decorator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>spi</artifactId>
-       <version>1.1-SNAPSHOT</version>
+       <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spi-bean-decorator</artifactId>

--- a/spi/bean-decorator/pom.xml
+++ b/spi/bean-decorator/pom.xml
@@ -19,20 +19,21 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-    
-    <parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>spi</artifactId>
        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spi-bean-decorator</artifactId>
-    <packaging>pom</packaging>
-    <name>Soteria SPI : Bean Decorator</name>
+   <artifactId>spi-bean-decorator</artifactId>
+   <packaging>pom</packaging>
 
-    <modules>
+   <name>Soteria SPI : Bean Decorator</name>
+
+   <modules>
         <module>weld</module>
     </modules>
-    
 </project>

--- a/spi/bean-decorator/weld/pom.xml
+++ b/spi/bean-decorator/weld/pom.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2015, 2018 Payara and/or its affiliates and others. 
+    Copyright (c) 2015, 2020 Payara and/or its affiliates and others. 
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,10 +24,11 @@
 	<parent>
 		<groupId>org.glassfish.soteria</groupId>
 		<artifactId>spi-bean-decorator</artifactId>
-		<version>1.1-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>soteria-bean-decorator-weld</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>Soteria SPI : Bean Decorator : Weld</name>
 
@@ -41,7 +42,7 @@
 		<dependency>
 			<groupId>org.glassfish.soteria</groupId>
 			<artifactId>javax.security.enterprise</artifactId>
-			<version>1.1-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	

--- a/spi/bean-decorator/weld/pom.xml
+++ b/spi/bean-decorator/weld/pom.xml
@@ -19,7 +19,8 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>org.glassfish.soteria</groupId>
@@ -29,6 +30,7 @@
 
 	<artifactId>soteria-bean-decorator-weld</artifactId>
 	<packaging>bundle</packaging>
+
 	<name>Soteria SPI : Bean Decorator : Weld</name>
 
 	<dependencies>
@@ -44,7 +46,7 @@
 			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<!-- This plugin is reponsible for packaging artifacts as OSGi bundles. 
@@ -53,10 +55,9 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+				<version>4.2.1</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>
 	</build>
-    
 </project>

--- a/spi/bean-decorator/weld/pom.xml
+++ b/spi/bean-decorator/weld/pom.xml
@@ -28,7 +28,6 @@
 	</parent>
 
 	<artifactId>soteria-bean-decorator-weld</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>Soteria SPI : Bean Decorator : Weld</name>
 
@@ -36,7 +35,7 @@
 		<dependency>
 			<groupId>org.jboss.weld</groupId>
 			<artifactId>weld-osgi-bundle</artifactId>
-			<version>3.0.4.Final</version>
+			<version>3.1.3.Final</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -54,6 +53,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/DecorableWeldBeanWrapper.java
+++ b/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/DecorableWeldBeanWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2018, 2020 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/DecorableWeldBeanWrapper.java
+++ b/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/DecorableWeldBeanWrapper.java
@@ -21,12 +21,12 @@ import static org.jboss.weld.util.Decorators.getOuterDelegate;
 import java.util.List;
 import java.util.Set;
 
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.Decorator;
-import javax.enterprise.inject.spi.InjectionPoint;
-import javax.enterprise.inject.spi.PassivationCapable;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.Decorator;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.PassivationCapable;
 
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotated;
 import org.jboss.weld.bean.AbstractBean;

--- a/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/WeldBeanDecorator.java
+++ b/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/WeldBeanDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2018, 2020 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/WeldBeanDecorator.java
+++ b/spi/bean-decorator/weld/src/main/java/org/glassfish/soteria/spi/bean/decorator/WeldBeanDecorator.java
@@ -16,8 +16,8 @@
  */
 package org.glassfish.soteria.spi.bean.decorator;
 
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.glassfish.soteria.cdi.spi.BeanDecorator;
 import org.jboss.weld.bean.builtin.BeanManagerProxy;

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Payara and/or its affiliates and others. 
+    Copyright (c) 2015, 2020 Payara and/or its affiliates and others. 
     All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -18,20 +18,21 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-    
-     <parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spi</artifactId>
-    <packaging>pom</packaging>
-    <name>Soteria SPI</name>
+   <artifactId>spi</artifactId>
+   <packaging>pom</packaging>
 
-    <modules>
+   <name>Soteria SPI</name>
+
+   <modules>
         <module>bean-decorator</module>
     </modules>
-
 </project>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -23,7 +23,7 @@
      <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.1-SNAPSHOT</version>
+       <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spi</artifactId>

--- a/test/app-custom-identity-store-handler/pom.xml
+++ b/test/app-custom-identity-store-handler/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -19,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
@@ -28,15 +29,11 @@
 	<artifactId>app-custom-identity-store-handler</artifactId>
 	<packaging>war</packaging>
 
-	<build>
-        <finalName>app-custom-identity-store-handler</finalName>
-	</build>
-
-    <properties>
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
 
-    <dependencies>
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
@@ -50,4 +47,7 @@
         </dependency>
     </dependencies>
 
+	<build>
+        <finalName>app-custom-identity-store-handler</finalName>
+	</build>
 </project>

--- a/test/app-custom-identity-store-handler/pom.xml
+++ b/test/app-custom-identity-store-handler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>app-custom-identity-store-handler</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/test/app-custom-identity-store-handler/pom.xml
+++ b/test/app-custom-identity-store-handler/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/BlackListedIdentityStore.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/BlackListedIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/BlackListedIdentityStore.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/BlackListedIdentityStore.java
@@ -16,18 +16,18 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
 import static org.glassfish.soteria.test.Utils.unmodifiableSet;
 
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 /**
  *

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/CustomIdentityStoreHandler.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/CustomIdentityStoreHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria.test;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.Priority;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.security.enterprise.CallerPrincipal;

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/CustomIdentityStoreHandler.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/CustomIdentityStoreHandler.java
@@ -18,24 +18,24 @@ package org.glassfish.soteria.test;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.Priority;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
-import static javax.interceptor.Interceptor.Priority.APPLICATION;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
+import static jakarta.interceptor.Interceptor.Priority.APPLICATION;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
 import static org.glassfish.soteria.test.CdiUtils.getBeanReferencesByType;
 
 /**

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/GroupProviderIdentityStore.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/GroupProviderIdentityStore.java
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
 import static org.glassfish.soteria.test.Utils.unmodifiableSet;
 
 import java.util.HashMap;
@@ -27,10 +27,10 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
-import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 
 /**
  *

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/GroupProviderIdentityStore.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/GroupProviderIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.security.enterprise.identitystore.CredentialValidationResult;
 import jakarta.security.enterprise.identitystore.IdentityStore;

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/LdapSetup.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/LdapSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,8 +22,8 @@ import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldif.LDIFReader;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,11 +19,11 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-identity-store-handler/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -17,20 +17,20 @@
 package org.glassfish.soteria.test;
 
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/beans.xml
+++ b/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-custom-identity-store-handler/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-identity-store-handler/src/test/java/org/glassfish/soteria/test/AppCustomIdentityStoreHandlerIT.java
+++ b/test/app-custom-identity-store-handler/src/test/java/org/glassfish/soteria/test/AppCustomIdentityStoreHandlerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/pom.xml
+++ b/test/app-custom-rememberme/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,30 +19,29 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-custom-rememberme</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-custom-rememberme</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-custom-rememberme</finalName>
+	</build>
 </project>

--- a/test/app-custom-rememberme/pom.xml
+++ b/test/app-custom-rememberme/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom-rememberme</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom-rememberme/pom.xml
+++ b/test/app-custom-rememberme/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,11 +19,11 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -17,22 +17,21 @@
 package org.glassfish.soteria.test;
 
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.authentication.mechanism.http.RememberMe;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @RememberMe(
     cookieMaxAgeSeconds = 3600,

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -17,16 +17,16 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
+++ b/test/app-custom-rememberme/src/main/java/org/glassfish/soteria/test/TestRememberMeIdentityStore.java
@@ -22,13 +22,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.CallerPrincipal;
-import javax.security.enterprise.credential.RememberMeCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.RememberMeIdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.credential.RememberMeCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.RememberMeIdentityStore;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 
 @ApplicationScoped
 public class TestRememberMeIdentityStore implements RememberMeIdentityStore {

--- a/test/app-custom-rememberme/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-custom-rememberme/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-custom-rememberme/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-custom-rememberme/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeHttpOnlyIT.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeHttpOnlyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeHttpOnlyImmediateIT.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeHttpOnlyImmediateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeIT.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeSecureOnlyIT.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/AppCustomRememberMeSecureOnlyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalse.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalse.java
@@ -18,9 +18,9 @@ package org.glassfish.soteria.test.alternatives;
 
 
 import javax.annotation.Priority;
-import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.Alternative;
-import javax.security.enterprise.authentication.mechanism.http.RememberMe;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;
 
 import org.glassfish.soteria.test.TestAuthenticationMechanism;
 

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalse.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 package org.glassfish.soteria.test.alternatives;
 
 
-import javax.annotation.Priority;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalseImmediate.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalseImmediate.java
@@ -18,9 +18,9 @@ package org.glassfish.soteria.test.alternatives;
 
 
 import javax.annotation.Priority;
-import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.Alternative;
-import javax.security.enterprise.authentication.mechanism.http.RememberMe;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;
 
 import org.glassfish.soteria.test.TestAuthenticationMechanism;
 

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalseImmediate.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismHttpOnlyFalseImmediate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 package org.glassfish.soteria.test.alternatives;
 
 
-import javax.annotation.Priority;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismSecureOnly.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismSecureOnly.java
@@ -18,9 +18,9 @@ package org.glassfish.soteria.test.alternatives;
 
 
 import javax.annotation.Priority;
-import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.Alternative;
-import javax.security.enterprise.authentication.mechanism.http.RememberMe;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;
 
 import org.glassfish.soteria.test.TestAuthenticationMechanism;
 

--- a/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismSecureOnly.java
+++ b/test/app-custom-rememberme/src/test/java/org/glassfish/soteria/test/alternatives/TestAuthenticationMechanismSecureOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 package org.glassfish.soteria.test.alternatives;
 
 
-import javax.annotation.Priority;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.security.enterprise.authentication.mechanism.http.RememberMe;

--- a/test/app-custom-session/pom.xml
+++ b/test/app-custom-session/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,30 +19,29 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-custom-session</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-custom-session</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-custom-session</finalName>
+	</build>
 </project>

--- a/test/app-custom-session/pom.xml
+++ b/test/app-custom-session/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-session/pom.xml
+++ b/test/app-custom-session/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom-session</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,11 +19,11 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -16,21 +16,21 @@
 
 package org.glassfish.soteria.test;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.AutoApplySession;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.AutoApplySession;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
 @ApplicationScoped
 @AutoApplySession

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom-session/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -17,16 +17,16 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-custom-session/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-custom-session/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-session/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-custom-session/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-session/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-custom-session/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom-session/src/test/java/org/glassfish/soteria/test/AppCustomSessionIT.java
+++ b/test/app-custom-session/src/test/java/org/glassfish/soteria/test/AppCustomSessionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/pom.xml
+++ b/test/app-custom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-custom</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-custom/pom.xml
+++ b/test/app-custom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/pom.xml
+++ b/test/app-custom/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -19,29 +20,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-custom</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-custom</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-custom</finalName>
+	</build>
 </project>

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
@@ -17,17 +17,16 @@
 package org.glassfish.soteria.test;
 
 import java.io.IOException;
-import java.util.List;
 
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HttpConstraint;
-import javax.servlet.annotation.ServletSecurity;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,13 +19,13 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 
 /**

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.inject.Inject;
 import jakarta.security.enterprise.SecurityContext;
 import jakarta.servlet.ServletException;

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -17,19 +17,19 @@
 package org.glassfish.soteria.test;
 
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-custom/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -17,14 +17,14 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-custom/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-custom/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-custom/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-custom/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/src/main/webapp/WEB-INF/web.xml
+++ b/test/app-custom/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-custom/src/test/java/org/glassfish/soteria/test/AppCustomIT.java
+++ b/test/app-custom/src/test/java/org/glassfish/soteria/test/AppCustomIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-db/pom.xml
+++ b/test/app-db/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-db</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         
          <dependency>

--- a/test/app-db/pom.xml
+++ b/test/app-db/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,25 +19,21 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-db</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-db</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
@@ -49,5 +46,8 @@
             <version>1.4.196</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-db</finalName>
+	</build>
 </project>

--- a/test/app-db/pom.xml
+++ b/test/app-db/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
@@ -16,10 +16,10 @@
 
 package org.glassfish.soteria.test;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
-import javax.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
-import javax.security.enterprise.identitystore.Pbkdf2PasswordHash;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+import jakarta.security.enterprise.identitystore.DatabaseIdentityStoreDefinition;
+import jakarta.security.enterprise.identitystore.Pbkdf2PasswordHash;
 
 @DatabaseIdentityStoreDefinition(
     dataSourceLookup = "${'java:global/MyDS'}",

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/DatabaseSetup.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/DatabaseSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,10 +22,10 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.annotation.Resource;
-import javax.annotation.sql.DataSourceDefinition;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Resource;
+import jakarta.annotation.sql.DataSourceDefinition;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import jakarta.inject.Inject;

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/DatabaseSetup.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/DatabaseSetup.java
@@ -28,9 +28,9 @@ import javax.annotation.Resource;
 import javax.annotation.sql.DataSourceDefinition;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.sql.DataSource;
-import javax.security.enterprise.identitystore.Pbkdf2PasswordHash;
+import jakarta.security.enterprise.identitystore.Pbkdf2PasswordHash;
 
 @DataSourceDefinition(
     // global to circumvent https://java.net/jira/browse/GLASSFISH-21447

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,11 +19,11 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-db/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -17,20 +17,20 @@
 package org.glassfish.soteria.test;
 
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-db/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-db/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-db/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-db/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-db/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-db/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
+++ b/test/app-db/src/test/java/org/glassfish/soteria/test/AppDBIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/pom.xml
+++ b/test/app-jaxrs/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -19,29 +20,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-jaxrs</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-jaxrs</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-jaxrs</finalName>
+	</build>
 </project>

--- a/test/app-jaxrs/pom.xml
+++ b/test/app-jaxrs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-jaxrs</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-jaxrs/pom.xml
+++ b/test/app-jaxrs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/JaxRsActivator.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/JaxRsActivator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,7 @@
 
 package org.glassfish.soteria.test;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/ProtectedResource.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/ProtectedResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/ProtectedResource.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/ProtectedResource.java
@@ -18,8 +18,8 @@ package org.glassfish.soteria.test;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/PublicResource.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/PublicResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/PublicResource.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/PublicResource.java
@@ -18,8 +18,8 @@ package org.glassfish.soteria.test;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-jaxrs/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -17,20 +17,20 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static org.glassfish.soteria.test.Utils.notNull;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-jaxrs/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-jaxrs/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-jaxrs/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-jaxrs/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/main/webapp/WEB-INF/web.xml
+++ b/test/app-jaxrs/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-jaxrs/src/test/java/org/glassfish/soteria/test/AppJaxRsIT.java
+++ b/test/app-jaxrs/src/test/java/org/glassfish/soteria/test/AppJaxRsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap/pom.xml
+++ b/test/app-ldap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-ldap</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/test/app-ldap/pom.xml
+++ b/test/app-ldap/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap/pom.xml
+++ b/test/app-ldap/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -17,25 +18,21 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
-	<artifactId>app-ldap</artifactId>
-	<packaging>war</packaging>
-    
-    <build>
-        <finalName>app-db</finalName>
-    </build>
-	
+
+    <artifactId>app-ldap</artifactId>
+    <packaging>war</packaging>
+
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
@@ -49,5 +46,8 @@
             <version>4.0.4</version>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <finalName>app-db</finalName>
+    </build>
 </project>

--- a/test/app-ldap/src/main/java/org/glassfish/soteria/test/LdapSetup.java
+++ b/test/app-ldap/src/main/java/org/glassfish/soteria/test/LdapSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria.test;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 

--- a/test/app-ldap/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-ldap/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,12 +19,12 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-ldap/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-ldap/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;

--- a/test/app-ldap/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -16,21 +16,21 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-ldap/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-ldap/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-ldap/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-ldap/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap/src/test/java/org/glassfish/soteria/test/AppLDAPIT.java
+++ b/test/app-ldap/src/test/java/org/glassfish/soteria/test/AppLDAPIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap2/pom.xml
+++ b/test/app-ldap2/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -28,15 +29,11 @@
 
     <artifactId>app-ldap2</artifactId>
     <packaging>war</packaging>
-    
-    <build>
-        <finalName>app-ldap2</finalName>
-    </build>
-    
+
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
@@ -51,4 +48,7 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>app-ldap2</finalName>
+    </build>
 </project>

--- a/test/app-ldap2/pom.xml
+++ b/test/app-ldap2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         
          <dependency>

--- a/test/app-ldap2/pom.xml
+++ b/test/app-ldap2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap2/src/main/java/org/glassfish/soteria/test/LdapSetup.java
+++ b/test/app-ldap2/src/main/java/org/glassfish/soteria/test/LdapSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,8 +22,8 @@ import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldif.LDIFReader;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 

--- a/test/app-ldap2/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-ldap2/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,7 @@
 
 package org.glassfish.soteria.test;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;

--- a/test/app-ldap2/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-ldap2/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -17,12 +17,12 @@
 package org.glassfish.soteria.test;
 
 import javax.annotation.security.DeclareRoles;
-import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/test/app-ldap2/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap2/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap2/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap2/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -16,21 +16,21 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-ldap2/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-ldap2/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap2/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-ldap2/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap2/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-ldap2/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap2/src/test/java/org/glassfish/soteria/test/AppLDAP2IT.java
+++ b/test/app-ldap2/src/test/java/org/glassfish/soteria/test/AppLDAP2IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap3/pom.xml
+++ b/test/app-ldap3/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -28,15 +29,11 @@
 
     <artifactId>app-ldap3</artifactId>
     <packaging>war</packaging>
-    
-    <build>
-        <finalName>app-ldap3</finalName>
-    </build>
-    
+
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
@@ -51,4 +48,7 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>app-ldap3</finalName>
+    </build>
 </project>

--- a/test/app-ldap3/pom.xml
+++ b/test/app-ldap3/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         
          <dependency>

--- a/test/app-ldap3/pom.xml
+++ b/test/app-ldap3/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap3/src/main/java/org/glassfish/soteria/test/LdapSetup.java
+++ b/test/app-ldap3/src/main/java/org/glassfish/soteria/test/LdapSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,8 +22,8 @@ import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldif.LDIFReader;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 

--- a/test/app-ldap3/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-ldap3/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,7 @@
 
 package org.glassfish.soteria.test;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;

--- a/test/app-ldap3/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-ldap3/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -17,12 +17,12 @@
 package org.glassfish.soteria.test;
 
 import javax.annotation.security.DeclareRoles;
-import javax.security.enterprise.identitystore.LdapIdentityStoreDefinition;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.identitystore.LdapIdentityStoreDefinition;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/test/app-ldap3/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap3/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap3/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-ldap3/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -16,21 +16,21 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-ldap3/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-ldap3/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap3/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-ldap3/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap3/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-ldap3/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-ldap3/src/test/java/org/glassfish/soteria/test/AppLDAP2IT.java
+++ b/test/app-ldap3/src/test/java/org/glassfish/soteria/test/AppLDAP2IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic-decorate/pom.xml
+++ b/test/app-mem-basic-decorate/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -16,27 +17,27 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"> <modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
-    <artifactId>app-mem-basic-decorate</artifactId>
-    <packaging>war</packaging>
-      
-    <properties>
+
+   <artifactId>app-mem-basic-decorate</artifactId>
+   <packaging>war</packaging>
+
+   <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+   <dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/test/app-mem-basic-decorate/pom.xml
+++ b/test/app-mem-basic-decorate/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
     <artifactId>app-mem-basic-decorate</artifactId>

--- a/test/app-mem-basic-decorate/pom.xml
+++ b/test/app-mem-basic-decorate/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic-decorate/src/main/java/test/AuthenticationMechanismDecorator.java
+++ b/test/app-mem-basic-decorate/src/main/java/test/AuthenticationMechanismDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2018, 2020 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,7 +18,7 @@ package test;
 
 import java.io.IOException;
 
-import javax.annotation.Priority;
+import jakarta.annotation.Priority;
 import jakarta.decorator.Decorator;
 import jakarta.decorator.Delegate;
 import jakarta.inject.Inject;

--- a/test/app-mem-basic-decorate/src/main/java/test/AuthenticationMechanismDecorator.java
+++ b/test/app-mem-basic-decorate/src/main/java/test/AuthenticationMechanismDecorator.java
@@ -19,16 +19,16 @@ package test;
 import java.io.IOException;
 
 import javax.annotation.Priority;
-import javax.decorator.Decorator;
-import javax.decorator.Delegate;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
 
 /**
  * This is a CDI decorator that decorates the authentication mechanism (in this test

--- a/test/app-mem-basic-decorate/src/main/java/test/Servlet.java
+++ b/test/app-mem-basic-decorate/src/main/java/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@ package test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.HttpConstraint;

--- a/test/app-mem-basic-decorate/src/main/java/test/Servlet.java
+++ b/test/app-mem-basic-decorate/src/main/java/test/Servlet.java
@@ -18,14 +18,14 @@ package test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HttpConstraint;
-import javax.servlet.annotation.ServletSecurity;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-mem-basic-decorate/src/main/java/test/TestIdentityStore.java
+++ b/test/app-mem-basic-decorate/src/main/java/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic-decorate/src/main/java/test/TestIdentityStore.java
+++ b/test/app-mem-basic-decorate/src/main/java/test/TestIdentityStore.java
@@ -17,14 +17,14 @@
 package test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 /**
  * A simple identity store for testing purposes only

--- a/test/app-mem-basic-decorate/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-mem-basic-decorate/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic-decorate/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-mem-basic-decorate/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic-decorate/src/test/java/org/glassfish/soteria/test/AppMemBasicDecorateIT.java
+++ b/test/app-mem-basic-decorate/src/test/java/org/glassfish/soteria/test/AppMemBasicDecorateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/test/app-mem-basic/pom.xml
+++ b/test/app-mem-basic/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic/pom.xml
+++ b/test/app-mem-basic/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,24 +19,20 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-	
+
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
     <artifactId>app-mem-basic</artifactId>
     <packaging>war</packaging>
-	
-    <build>
-        <finalName>app-mem-basic</finalName>
-    </build>
-      
+
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
@@ -44,4 +41,7 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <finalName>app-mem-basic</finalName>
+    </build>
 </project>

--- a/test/app-mem-basic/pom.xml
+++ b/test/app-mem-basic/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
     <artifactId>app-mem-basic</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-basic/src/main/java/test/Servlet.java
+++ b/test/app-mem-basic/src/main/java/test/Servlet.java
@@ -19,14 +19,14 @@ package test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HttpConstraint;
-import javax.servlet.annotation.ServletSecurity;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-mem-basic/src/main/java/test/Servlet.java
+++ b/test/app-mem-basic/src/main/java/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.HttpConstraint;

--- a/test/app-mem-basic/src/main/java/test/TestIdentityStore.java
+++ b/test/app-mem-basic/src/main/java/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic/src/main/java/test/TestIdentityStore.java
+++ b/test/app-mem-basic/src/main/java/test/TestIdentityStore.java
@@ -17,14 +17,14 @@
 package test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-mem-basic/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-mem-basic/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-mem-basic/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-mem-basic/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-basic/src/test/java/org/glassfish/soteria/test/AppMemBasicIT.java
+++ b/test/app-mem-basic/src/test/java/org/glassfish/soteria/test/AppMemBasicIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/pom.xml
+++ b/test/app-mem-customform/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,25 +19,21 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-mem-customform</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-mem-customform</finalName>
-	</build>
 
-    <properties>
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
@@ -44,4 +41,7 @@
         </dependency>
     </dependencies>
 
+	<build>
+        <finalName>app-mem-customform</finalName>
+	</build>
 </project>

--- a/test/app-mem-customform/pom.xml
+++ b/test/app-mem-customform/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem-customform</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-customform/pom.xml
+++ b/test/app-mem-customform/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/LoginBacking.java
+++ b/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/LoginBacking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/LoginBacking.java
+++ b/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/LoginBacking.java
@@ -17,24 +17,24 @@
 package org.glassfish.soteria.test;
 
 import static javax.faces.application.FacesMessage.SEVERITY_ERROR;
-import static javax.security.enterprise.AuthenticationStatus.SEND_CONTINUE;
-import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
-import static javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
+import static jakarta.security.enterprise.AuthenticationStatus.SEND_CONTINUE;
+import static jakarta.security.enterprise.AuthenticationStatus.SEND_FAILURE;
+import static jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
 
-import javax.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.RequestScoped;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.SecurityContext;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 @Named
 @RequestScoped

--- a/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.security.enterprise.authentication.mechanism.http.CustomFormAuthenticationMechanismDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
 import jakarta.servlet.ServletException;

--- a/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,15 +19,15 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.security.enterprise.authentication.mechanism.http.CustomFormAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HttpConstraint;
-import javax.servlet.annotation.ServletSecurity;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.security.enterprise.authentication.mechanism.http.CustomFormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem-customform/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -17,14 +17,14 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-mem-customform/src/main/webapp/WEB-INF/faces-config.xml
+++ b/test/app-mem-customform/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-mem-customform/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-mem-customform/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-mem-customform/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/main/webapp/login.xhtml
+++ b/test/app-mem-customform/src/main/webapp/login.xhtml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-customform/src/test/java/org/glassfish/soteria/test/AppMemCustomFormIT.java
+++ b/test/app-mem-customform/src/test/java/org/glassfish/soteria/test/AppMemCustomFormIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/pom.xml
+++ b/test/app-mem-form/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem-form</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/test/app-mem-form/pom.xml
+++ b/test/app-mem-form/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/pom.xml
+++ b/test/app-mem-form/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,25 +19,21 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-mem-form</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-mem-form</finalName>
-	</build>
 
-    <properties>
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
@@ -44,4 +41,7 @@
         </dependency>
     </dependencies>
 
+	<build>
+        <finalName>app-mem-form</finalName>
+	</build>
 </project>

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/ApplicationConfig.java
@@ -16,9 +16,9 @@
 
 package org.glassfish.soteria.test;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
 
 @FormAuthenticationMechanismDefinition(
     loginToContinue = @LoginToContinue(

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginErrorServlet.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginErrorServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginErrorServlet.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginErrorServlet.java
@@ -18,11 +18,11 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Servlet that is invoked when the caller did not authenticate correctly

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginServlet.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginServlet.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/LoginServlet.java
@@ -18,11 +18,11 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Servlet that is invoked when it's determined that the caller needs to authenticate/login.

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,13 +19,13 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HttpConstraint;
-import javax.servlet.annotation.ServletSecurity;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.HttpConstraint;
 import jakarta.servlet.annotation.ServletSecurity;

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem-form/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -17,14 +17,14 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-mem-form/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-mem-form/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-mem-form/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-mem-form/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/test/java/org/glassfish/soteria/test/AppMemFormIT.java
+++ b/test/app-mem-form/src/test/java/org/glassfish/soteria/test/AppMemFormIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/test/java/org/glassfish/soteria/test/AppMemFormImmediateIT.java
+++ b/test/app-mem-form/src/test/java/org/glassfish/soteria/test/AppMemFormImmediateIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/ApplicationConfigImmediate.java
+++ b/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/ApplicationConfigImmediate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/ApplicationConfigImmediate.java
+++ b/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/ApplicationConfigImmediate.java
@@ -16,10 +16,10 @@
 
 package org.glassfish.soteria.test.alternatives;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Named;
-import javax.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
-import javax.security.enterprise.authentication.mechanism.http.LoginToContinue;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+import jakarta.security.enterprise.authentication.mechanism.http.FormAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.LoginToContinue;
 
 @FormAuthenticationMechanismDefinition(
     loginToContinue = @LoginToContinue(

--- a/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/LoginServletAlt.java
+++ b/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/LoginServletAlt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/LoginServletAlt.java
+++ b/test/app-mem-form/src/test/java/org/glassfish/soteria/test/alternatives/LoginServletAlt.java
@@ -18,11 +18,11 @@ package org.glassfish.soteria.test.alternatives;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Servlet that is invoked when it's determined that the caller needs to authenticate/login.

--- a/test/app-mem/pom.xml
+++ b/test/app-mem/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,30 +19,29 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-mem</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-mem</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-mem</finalName>
+	</build>
 </project>

--- a/test/app-mem/pom.xml
+++ b/test/app-mem/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem/pom.xml
+++ b/test/app-mem/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-mem</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,11 +19,11 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -16,21 +16,21 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-mem/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -17,14 +17,14 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-mem/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-mem/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-mem/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-mem/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-mem/src/test/java/org/glassfish/soteria/test/AppMemIT.java
+++ b/test/app-mem/src/test/java/org/glassfish/soteria/test/AppMemIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/pom.xml
+++ b/test/app-multiple-store-backup/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-multiple-store-backup</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store-backup/pom.xml
+++ b/test/app-multiple-store-backup/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/pom.xml
+++ b/test/app-multiple-store-backup/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,30 +19,29 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-multiple-store-backup</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-multiple-store-backup</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-multiple-store-backup</finalName>
+	</build>
 </project>

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,11 +19,11 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -16,21 +16,21 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
@@ -17,16 +17,16 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @ApplicationScoped
 public class TestBackupIdentityStore implements IdentityStore {

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestBackupIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
+++ b/test/app-multiple-store-backup/src/main/java/org/glassfish/soteria/test/TestIdentityStore.java
@@ -17,16 +17,16 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.RequestScoped;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 @RequestScoped
 public class TestIdentityStore implements IdentityStore {

--- a/test/app-multiple-store-backup/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-multiple-store-backup/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-multiple-store-backup/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/src/main/webapp/WEB-INF/ibm-web-ext.xml
+++ b/test/app-multiple-store-backup/src/main/webapp/WEB-INF/ibm-web-ext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-multiple-store-backup/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store-backup/src/test/java/org/glassfish/soteria/test/AppMultipleStoreBackupIT.java
+++ b/test/app-multiple-store-backup/src/test/java/org/glassfish/soteria/test/AppMultipleStoreBackupIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store/pom.xml
+++ b/test/app-multiple-store/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-multiple-store</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-multiple-store/pom.xml
+++ b/test/app-multiple-store/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -18,30 +19,29 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
-    <parent>
+
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-multiple-store</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-multiple-store</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-multiple-store</finalName>
+	</build>
 </project>

--- a/test/app-multiple-store/pom.xml
+++ b/test/app-multiple-store/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthenticationIdentityStore.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthenticationIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.security.enterprise.credential.Credential;
 import jakarta.security.enterprise.credential.UsernamePasswordCredential;

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthenticationIdentityStore.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthenticationIdentityStore.java
@@ -17,9 +17,9 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,11 +27,11 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.credential.Credential;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 /**
  *

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.security.enterprise.identitystore.CredentialValidationResult;
 import jakarta.security.enterprise.identitystore.IdentityStore;

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/AuthorizationIdentityStore.java
@@ -17,7 +17,7 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
+import static jakarta.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
 
 /**
  *

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -19,11 +19,11 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,7 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-multiple-store/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -16,22 +16,22 @@
 
 package org.glassfish.soteria.test;
 
-import javax.enterprise.context.ApplicationScoped;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import jakarta.enterprise.context.ApplicationScoped;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
 import static org.glassfish.soteria.test.Utils.notNull;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.Password;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.security.enterprise.identitystore.IdentityStoreHandler;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.Password;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-multiple-store/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-multiple-store/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-multiple-store/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-multiple-store/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-multiple-store/src/test/java/org/glassfish/soteria/test/AppMultipleStoreIT.java
+++ b/test/app-multiple-store/src/test/java/org/glassfish/soteria/test/AppMultipleStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-auth/pom.xml
+++ b/test/app-securitycontext-auth/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext-auth</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext-auth/pom.xml
+++ b/test/app-securitycontext-auth/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -19,29 +20,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-securitycontext-auth</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-securitycontext-auth</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-securitycontext-auth</finalName>
+	</build>
 </project>

--- a/test/app-securitycontext-auth/pom.xml
+++ b/test/app-securitycontext-auth/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,7 @@ import static org.glassfish.soteria.test.Utils.notNull;
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.inject.Inject;
 import jakarta.security.enterprise.AuthenticationStatus;
 import jakarta.security.enterprise.SecurityContext;

--- a/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -16,21 +16,21 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
+import static jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
 import static org.glassfish.soteria.test.Utils.notNull;
 
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.inject.Inject;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.SecurityContext;
-import javax.security.enterprise.credential.CallerOnlyCredential;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.security.enterprise.credential.CallerOnlyCredential;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext-auth/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -17,19 +17,19 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.AuthenticationStatus.SEND_FAILURE;
+import static jakarta.security.enterprise.AuthenticationStatus.SEND_FAILURE;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.CallerOnlyCredential;
-import javax.security.enterprise.credential.Credential;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.CallerOnlyCredential;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-securitycontext-auth/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-securitycontext-auth/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-auth/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-securitycontext-auth/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-auth/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-securitycontext-auth/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-auth/src/main/webapp/WEB-INF/web.xml
+++ b/test/app-securitycontext-auth/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-auth/src/test/java/org/glassfish/soteria/test/AppSecurityContextAuthIT.java
+++ b/test/app-securitycontext-auth/src/test/java/org/glassfish/soteria/test/AppSecurityContextAuthIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/pom.xml
+++ b/test/app-securitycontext-customprincipal/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -19,29 +20,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-securitycontext-customprincipal</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-securitycontext-customprincipal</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-securitycontext-customprincipal</finalName>
+	</build>
 </project>

--- a/test/app-securitycontext-customprincipal/pom.xml
+++ b/test/app-securitycontext-customprincipal/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/pom.xml
+++ b/test/app-securitycontext-customprincipal/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext-customprincipal</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/CustomCallerPrincipal.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/CustomCallerPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/CustomCallerPrincipal.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/CustomCallerPrincipal.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.soteria.test;
 
-import javax.security.enterprise.CallerPrincipal;
+import jakarta.security.enterprise.CallerPrincipal;
 
 public class CustomCallerPrincipal extends CallerPrincipal {
 

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/CustomPrincipal.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/CustomPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Ejb.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Ejb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Ejb.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Ejb.java
@@ -19,8 +19,8 @@ package org.glassfish.soteria.test;
 import java.security.Principal;
 
 import javax.ejb.Stateless;
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
 import java.util.Set;
 
 @Stateless

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/EjbServlet.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/EjbServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@ import static jakarta.security.enterprise.authentication.mechanism.http.Authenti
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.inject.Inject;
 import jakarta.security.enterprise.SecurityContext;
 import jakarta.servlet.ServletException;

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/EjbServlet.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/EjbServlet.java
@@ -16,18 +16,18 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
+import static jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
 
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.security.Principal;
 
 /**
@@ -38,6 +38,8 @@ import java.security.Principal;
 @DeclareRoles("admin")
 @WebServlet("/ejb-servlet")
 public class EjbServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
 
     @Inject
     private SecurityContext securityContext;

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@ import static jakarta.security.enterprise.authentication.mechanism.http.Authenti
 
 import java.io.IOException;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.inject.Inject;
 import jakarta.security.enterprise.SecurityContext;
 import jakarta.servlet.ServletException;

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -16,18 +16,18 @@
 
 package org.glassfish.soteria.test;
 
-import static javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
+import static jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
 
 import java.io.IOException;
 
 import javax.annotation.security.DeclareRoles;
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.security.Principal;
 
 /**
@@ -37,6 +37,8 @@ import java.security.Principal;
 @DeclareRoles("admin")
 @WebServlet("/servlet")
 public class Servlet extends HttpServlet {
+    
+    private static final long serialVersionUID = 1L;
 
     @Inject
     private SecurityContext securityContext;

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext-customprincipal/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -18,13 +18,13 @@ package org.glassfish.soteria.test;
 
 import static java.util.Collections.singleton;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-securitycontext-customprincipal/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
+++ b/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
+++ b/test/app-securitycontext-customprincipal/src/test/java/org/glassfish/soteria/test/AppSecurityContextCallerPrincipalIT.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -69,7 +68,7 @@ public class AppSecurityContextCallerPrincipalIT extends ArquillianBase {
                 containerPrincipal.contains("org.jboss.security.SimplePrincipal") ||
                 containerPrincipal.contains("org.jboss.security.SimpleGroup") ||
                 containerPrincipal.contains("org.apache.tomee.catalina.TomcatSecurityService$TomcatUser") ||
-                containerPrincipal.contains("javax.security.enterprise.CallerPrincipal") ||
+                containerPrincipal.contains("jakarta.security.enterprise.CallerPrincipal") ||
                 containerPrincipal.contains(inputApplicationPrincipal);
         boolean isApplicationPrincipalCorrect = applicationPrincipal.contains(inputApplicationPrincipal);
         return isContainerPricipalCorrect && isApplicationPrincipalCorrect;

--- a/test/app-securitycontext/pom.xml
+++ b/test/app-securitycontext/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -19,29 +20,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
+	<parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-	
+
 	<artifactId>app-securitycontext</artifactId>
 	<packaging>war</packaging>
-	
-	<build>
-        <finalName>app-securitycontext</finalName>
-	</build>
-    
-    <properties>
+
+	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
-    
-    <dependencies>
+
+	<dependencies>
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
-    
+
+	<build>
+        <finalName>app-securitycontext</finalName>
+	</build>
 </project>

--- a/test/app-securitycontext/pom.xml
+++ b/test/app-securitycontext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>app-securitycontext</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.glassfish.soteria.test</groupId>
             <artifactId>common</artifactId>
-            <version>1.1-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/test/app-securitycontext/pom.xml
+++ b/test/app-securitycontext/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/ProtectedServlet.java
@@ -18,15 +18,15 @@ package org.glassfish.soteria.test;
 
 import java.io.IOException;
 
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HttpConstraint;
-import javax.servlet.annotation.ServletSecurity;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -20,13 +20,13 @@ import java.io.IOException;
 import java.util.Set;
 
 import javax.annotation.security.DeclareRoles;
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Test Servlet that prints out the name of the authenticated caller and whether

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/Servlet.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@ package org.glassfish.soteria.test;
 import java.io.IOException;
 import java.util.Set;
 
-import javax.annotation.security.DeclareRoles;
+import jakarta.annotation.security.DeclareRoles;
 import jakarta.inject.Inject;
 import jakarta.security.enterprise.SecurityContext;
 import jakarta.servlet.ServletException;

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestAuthenticationMechanism.java
@@ -17,20 +17,20 @@
 package org.glassfish.soteria.test;
 
 import static java.util.Arrays.asList;
-import static javax.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
 import static org.glassfish.soteria.test.Utils.notNull;
 
 import java.util.HashSet;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.security.enterprise.AuthenticationException;
-import javax.security.enterprise.AuthenticationStatus;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.security.enterprise.credential.UsernamePasswordCredential;
-import javax.security.enterprise.identitystore.CredentialValidationResult;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @ApplicationScoped
 public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestEJB.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestEJB.java
@@ -27,8 +27,8 @@ import javax.annotation.security.DeclareRoles;
 import javax.annotation.security.PermitAll;
 import javax.ejb.EJBContext;
 import javax.ejb.Stateless;
-import javax.inject.Inject;
-import javax.security.enterprise.SecurityContext;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
 
 
 @Stateless

--- a/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestEJB.java
+++ b/test/app-securitycontext/src/main/java/org/glassfish/soteria/test/TestEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,9 +22,9 @@ import static org.glassfish.soteria.test.Utils.getELProcessor;
 import java.security.Principal;
 import java.util.Set;
 
-import javax.annotation.Resource;
-import javax.annotation.security.DeclareRoles;
-import javax.annotation.security.PermitAll;
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.annotation.security.PermitAll;
 import javax.ejb.EJBContext;
 import javax.ejb.Stateless;
 import jakarta.inject.Inject;

--- a/test/app-securitycontext/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/test/app-securitycontext/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/test/app-securitycontext/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/test/app-securitycontext/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext/src/main/webapp/WEB-INF/web.xml
+++ b/test/app-securitycontext/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/app-securitycontext/src/test/java/org/glassfish/soteria/test/AppSecurityContextIT.java
+++ b/test/app-securitycontext/src/test/java/org/glassfish/soteria/test/AppSecurityContextIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
@@ -17,16 +18,15 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>common</artifactId>
-    
     <packaging>jar</packaging>
 
     <dependencies>

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.soteria.test</groupId>
         <artifactId>parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>common</artifactId>

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>provided</scope>
         </dependency>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.29</version>
+            <version>2.37.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/test/common/src/main/java/org/glassfish/soteria/test/AnyAnnotationLiteral.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/AnyAnnotationLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/java/org/glassfish/soteria/test/AnyAnnotationLiteral.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/AnyAnnotationLiteral.java
@@ -16,8 +16,8 @@
 
 package org.glassfish.soteria.test;
 
-import javax.enterprise.inject.Any;
-import javax.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.util.AnnotationLiteral;
 
 /**
  * An annotation literal for @Any.

--- a/test/common/src/main/java/org/glassfish/soteria/test/ArquillianBase.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/ArquillianBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/java/org/glassfish/soteria/test/ArquillianBase.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/ArquillianBase.java
@@ -77,7 +77,7 @@ public class ArquillianBase {
             @Override
             public void printContentIfNecessary(WebResponse webResponse) {
                 int statusCode = webResponse.getStatusCode();
-                if (getOptions().getPrintContentOnFailingStatusCode() && !(statusCode >= SC_OK && statusCode < SC_MULTIPLE_CHOICES)) {
+                if (getOptions().isPrintContentOnFailingStatusCode() && !(statusCode >= SC_OK && statusCode < SC_MULTIPLE_CHOICES)) {
                     logger.log(SEVERE, webResponse.getWebRequest().getUrl().toExternalForm());
                 }
                 super.printContentIfNecessary(webResponse);

--- a/test/common/src/main/java/org/glassfish/soteria/test/Assert.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/Assert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/java/org/glassfish/soteria/test/CdiUtils.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/CdiUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/java/org/glassfish/soteria/test/CdiUtils.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/CdiUtils.java
@@ -31,10 +31,10 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;

--- a/test/common/src/main/java/org/glassfish/soteria/test/ShrinkWrap.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/ShrinkWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/java/org/glassfish/soteria/test/TestPlaintextPasswordHash.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/TestPlaintextPasswordHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/java/org/glassfish/soteria/test/TestPlaintextPasswordHash.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/TestPlaintextPasswordHash.java
@@ -18,8 +18,8 @@ package org.glassfish.soteria.test;
 
 import java.util.Map;
 
-import javax.enterprise.context.Dependent;
-import javax.security.enterprise.identitystore.PasswordHash;
+import jakarta.enterprise.context.Dependent;
+import jakarta.security.enterprise.identitystore.PasswordHash;
 
 @Dependent
 public class TestPlaintextPasswordHash implements PasswordHash {

--- a/test/common/src/main/java/org/glassfish/soteria/test/Utils.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/java/org/glassfish/soteria/test/Utils.java
+++ b/test/common/src/main/java/org/glassfish/soteria/test/Utils.java
@@ -46,12 +46,12 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
-import javax.el.ELProcessor;
-import javax.interceptor.InvocationContext;
-import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.enterprise.authentication.mechanism.http.HttpMessageContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.el.ELProcessor;
+import jakarta.interceptor.InvocationContext;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import javax.xml.bind.DatatypeConverter;
 
 /**

--- a/test/common/src/main/resources/arquillian.xml
+++ b/test/common/src/main/resources/arquillian.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/common/src/main/resources/server.xml
+++ b/test/common/src/main/resources/server.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -32,66 +32,6 @@
 
     <name>Soteria Integration Tests and Examples</name>
 
-    <properties>
-        <!-- Test servers -->
-        
-        <!-- Note: Payara 5.194 has EE Security (Soteria) included, and can be updated via this pom -->
-        <payara.version>5.194</payara.version>
-        
-        <glassfish.version>LATEST</glassfish.version>
-        
-        <!-- Note: WildFly 13 has EE Security (Soteria) included, but not activated -->
-        <wildfly.version>12.0.0.Final</wildfly.version>
-        
-        <tomee.version>7.0.4</tomee.version>
-        
-        <!-- Note: Liberty 18.0.0.2 has EE Security included -->
-        <openliberty.version>18.0.0.1</openliberty.version>
-        
-        <arquillian-glassfish-managed-3.1.version>1.0.2</arquillian-glassfish-managed-3.1.version>
-        <arquillian-glassfish-embedded-3.1.version>1.0.2</arquillian-glassfish-embedded-3.1.version>
-        <arquillian-glassfish-remote-3.1.version>1.0.2</arquillian-glassfish-remote-3.1.version>
-        <arquillian-payara-server-managed.version>2.1</arquillian-payara-server-managed.version>
-        <wildfly-arquillian-container-managed.version>2.1.0.Final</wildfly-arquillian-container-managed.version>
-		
-		<jacc-provider.version>0.3</jacc-provider.version>
-        
-        <foo>${session.executionRootDirectory}</foo>
-    </properties>
-    
-    
-    <repositories>
-    
-        <!-- Make sure Maven central is consulted first -->
-        <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-
-            <url>https://repo.maven.apache.org/maven2</url>
-
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    
-        <repository>
-            <id>payara-milestones</id>
-            <name>Payara Milestones</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-
-
     <!-- 
                 M O D U L E S
                 
@@ -99,7 +39,6 @@
                 module which contains utility code.  
                 
     -->
-
     <modules>
         <module>common</module>
 
@@ -132,6 +71,32 @@
         <module>app-jaxrs</module>
     </modules>
 
+    <properties>
+        <!-- Test servers -->
+        
+        <!-- Note: Payara 5.194 has EE Security (Soteria) included, and can be updated via this pom -->
+        <payara.version>5.194</payara.version>
+        
+        <glassfish.version>LATEST</glassfish.version>
+        
+        <!-- Note: WildFly 13 has EE Security (Soteria) included, but not activated -->
+        <wildfly.version>12.0.0.Final</wildfly.version>
+        
+        <tomee.version>7.0.4</tomee.version>
+        
+        <!-- Note: Liberty 18.0.0.2 has EE Security included -->
+        <openliberty.version>18.0.0.1</openliberty.version>
+        
+        <arquillian-glassfish-managed-3.1.version>1.0.2</arquillian-glassfish-managed-3.1.version>
+        <arquillian-glassfish-embedded-3.1.version>1.0.2</arquillian-glassfish-embedded-3.1.version>
+        <arquillian-glassfish-remote-3.1.version>1.0.2</arquillian-glassfish-remote-3.1.version>
+        <arquillian-payara-server-managed.version>2.1</arquillian-payara-server-managed.version>
+        <wildfly-arquillian-container-managed.version>2.1.0.Final</wildfly-arquillian-container-managed.version>
+		
+		<jacc-provider.version>0.3</jacc-provider.version>
+        
+        <foo>${session.executionRootDirectory}</foo>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -139,8 +104,8 @@
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>1.6.0.Final</version>
-                <scope>import</scope>
                 <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
@@ -150,8 +115,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -180,6 +143,35 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+    
+        <!-- Make sure Maven central is consulted first -->
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+
+            <url>https://repo.maven.apache.org/maven2</url>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    
+        <repository>
+            <id>payara-milestones</id>
+            <name>Payara Milestones</name>
+            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <build>
         <pluginManagement>
@@ -217,8 +209,6 @@
         </plugins>
     </build>
 
-
-
     <!-- 
     
             P R O F I L E S
@@ -230,8 +220,6 @@
             2. The server against which the tests should be done
     
      -->
-
-
     <profiles>
         <!--
             This profile assumes a target that already has the Soteria libraries.
@@ -471,8 +459,8 @@
             <dependencies>
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-4-remote</artifactId> 
-                    <version>${arquillian-payara-server-managed.version}</version> 
+                    <artifactId>arquillian-payara-server-4-remote</artifactId>
+                    <version>${arquillian-payara-server-managed.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -484,8 +472,8 @@
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-glassfish-remote-3.1</artifactId> 
-                    <version>${arquillian-glassfish-remote-3.1.version}</version> 
+                    <artifactId>arquillian-glassfish-remote-3.1</artifactId>
+                    <version>${arquillian-glassfish-remote-3.1.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -681,9 +669,9 @@
                     <groupId>org.apache.tomee</groupId>
                     <artifactId>apache-tomee</artifactId>
                     <version>${tomee.version}</version>
-                    <scope>test</scope>
                     <type>zip</type>
                     <classifier>plus</classifier>
+                    <scope>test</scope>
                 </dependency>
 
                 <dependency>
@@ -965,5 +953,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
        <groupId>org.glassfish.soteria</groupId>
        <artifactId>parent</artifactId>
-       <version>1.1-SNAPSHOT</version>
+       <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.soteria.test</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -117,6 +117,22 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>2.1.6</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.faces</groupId>
+            <artifactId>jakarta.faces-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.0-M1</version>
+        </dependency>
+    
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13</version>
@@ -139,7 +155,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.12.2</version>
+            <version>1.12.2</version><!--$NO-MVN-MAN-VER$-->
         </dependency>
     </dependencies>
 
@@ -233,8 +249,8 @@
             </activation>
             <dependencies>
                 <dependency>
-                   <groupId>javax.security.enterprise</groupId>
-                   <artifactId>javax.security.enterprise-api</artifactId>
+                   <groupId>jakarta.security.enterprise</groupId>
+                   <artifactId>jakarta.security.enterprise-api</artifactId>
                    <version>${api_dependency_version}</version>
                    <scope>provided</scope>
                 </dependency>
@@ -246,7 +262,7 @@
             This profile assumes a target that does not have the Soteria libraries.
             E.g. a Java EE 7 server or Servlet container such as Tomcat or Jetty.
 
-            With this profile e.g. javax.security.enterprise-1.0-b07-SNAPSHOT.jar
+            With this profile e.g. jakarta.security.enterprise-2.0.0.jar
             will end up in WEB-INF/lib
         -->
         <profile>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -48,17 +48,11 @@
         <!-- Note: Liberty 18.0.0.2 has EE Security included -->
         <openliberty.version>18.0.0.1</openliberty.version>
         
-        <arquillian-bom.version>1.4.0.Final</arquillian-bom.version>
-        <junit.version>4.12</junit.version>
-        <htmlunit.version>2.30</htmlunit.version>
-        <jsoup.version>1.11.3</jsoup.version>
-        <failsafe-plugin.version>2.21.0</failsafe-plugin.version>
         <arquillian-glassfish-managed-3.1.version>1.0.2</arquillian-glassfish-managed-3.1.version>
         <arquillian-glassfish-embedded-3.1.version>1.0.2</arquillian-glassfish-embedded-3.1.version>
         <arquillian-glassfish-remote-3.1.version>1.0.2</arquillian-glassfish-remote-3.1.version>
-        <arquillian-payara-server-4-managed.version>1.0.Beta3</arquillian-payara-server-4-managed.version>
+        <arquillian-payara-server-managed.version>2.1</arquillian-payara-server-managed.version>
         <wildfly-arquillian-container-managed.version>2.1.0.Final</wildfly-arquillian-container-managed.version>
-        <docker-maven-plugin.version>0.26.0</docker-maven-plugin.version>
 		
 		<jacc-provider.version>0.3</jacc-provider.version>
         
@@ -144,14 +138,14 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>${arquillian-bom.version}</version>
+                <version>1.6.0.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
                 <artifactId>payara-client-ee8</artifactId>
-                <version>1.0.Beta3-m1</version>
+                <version>2.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -162,7 +156,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 
@@ -175,24 +169,37 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>${htmlunit.version}</version>
+            <version>2.37.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>${jsoup.version}</version>
+            <version>1.12.2</version>
         </dependency>
     </dependencies>
 
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.0.0-M4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${failsafe-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -373,8 +380,8 @@
                 <!-- The actual Arquillian connector -->
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
-                    <artifactId>arquillian-payara-server-4-managed</artifactId>
-                    <version>1.0.Beta3</version>
+                    <artifactId>arquillian-payara-server-managed</artifactId>
+                    <version>${arquillian-payara-server-managed.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -415,7 +422,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${failsafe-plugin.version}</version>
                         <executions>
                             <execution>
                                 <goals>
@@ -466,7 +472,7 @@
                 <dependency>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-4-remote</artifactId> 
-                    <version>${arquillian-payara-server-4-managed.version}</version> 
+                    <version>${arquillian-payara-server-managed.version}</version> 
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -893,7 +899,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>${docker-maven-plugin.version}</version>
+                        <version>0.33.0</version>
                         <configuration>
                             <images>
                                 <image>
@@ -919,6 +925,7 @@
                 </plugins>
             </build>
         </profile>
+        
         <profile>
             <id>payara-docker</id>
             <build>


### PR DESCRIPTION
Soteria is updated to use Jakarta packages.

NOTE: Since there is no server yet using Jakarta packages for Servlet, REST, etc this can not be tested at the moment.

This PR implements "javax -> jakarta Compatible Implementation updates" for https://github.com/eclipse-ee4j/security-api/issues/156