### PR TITLE
Switch to OpenJDK 8 instead of Oracle JDK 8 as the Travis environment…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 env:
   - SERVER=payara-ci-managed-update,payara-ci-managed,provided


### PR DESCRIPTION
… is presently rejecting builds using versions prior to Oracle JDK 9.