### PR TITLE
Cleaned up poms for compilation with JDK 11 and easier staging

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -27,7 +27,6 @@
     </parent>
 
     <artifactId>jakarta.security.enterprise</artifactId>
-    <packaging>bundle</packaging>
 
     <name>Soteria ${project.version}</name>
     <description>EE4J Compatible Implementation for Java EE Security API</description>
@@ -49,7 +48,7 @@
                         <Bundle-SymbolicName>org.glassfish.jakarta.security.enterprise</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Bundle-Name>Soteria Jakarta Security Implementation ${project.version}</Bundle-Name>
-                        <Bundle-Description>Eclipse Jakarta Security Implementation (jakarta.security/3.0) ${project.version}</Bundle-Description>                        
+                        <Bundle-Description>Eclipse Jakarta Security Implementation (jakarta.security/3.0) ${project.version}</Bundle-Description>                      
                         
                         <Specification-Title>Jakarta Security</Specification-Title>
                         <Specification-Version>3.0</Specification-Version>
@@ -72,6 +71,51 @@
                         </Import-Package>
                     </instructions>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.glassfish.soteria</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            
+            <!-- Configure the jar with the javadoc. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-api-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalJOption>-Xdoclint:none</additionalJOption>
+                            <notimestamp>true</notimestamp>
+                            <splitindex>true</splitindex>
+                            <doctitle>${project.name} ${project.version}</doctitle>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
     <modules>
         <module>impl</module>
         <module>spi</module>
-        <module>test</module>
     </modules>
 
     <scm>
@@ -73,13 +72,13 @@
     </scm>
 
     <properties>
-        <api_dependency_version>2.0.0-RC1</api_dependency_version>
+        <api_dependency_version>2.0.0-RC2</api_dependency_version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -97,7 +96,7 @@
         <dependency>
             <groupId>jakarta.interceptor</groupId>
             <artifactId>jakarta.interceptor-api</artifactId>
-            <version>2.0.0-RC1</version>
+            <version>2.0.0-RC2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,7 +108,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>3.0.0-M1</version>
+            <version>3.0.0-M4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -182,7 +181,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -199,31 +198,32 @@
                     </execution>
                 </executions>
             </plugin> 
-            <!-- Configure the jar with the sources (or rather, convince Maven that
-                we want sources at all) -->
+            
+           <!-- Configure the jar with the sources. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-            </plugin>
-
-            <!-- Configure the jar with the javadoc (or rather, convince Maven that
-                we want javadoc at all) -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
-                <configuration>
-                    <javadocVersion>1.8</javadocVersion>
-                    <notimestamp>true</notimestamp>
-                    <splitindex>true</splitindex>
-                    <doctitle>${project.name} ${project.version}</doctitle>
-                </configuration>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
+        <profile>
+            <id>test</id>
+            <modules>
+                <module>test</module>
+            </modules>
+        </profile>
+    
         <profile>
             <id>only-eclipse</id>
             <activation>

--- a/spi/bean-decorator/weld/pom.xml
+++ b/spi/bean-decorator/weld/pom.xml
@@ -29,7 +29,6 @@
 	</parent>
 
 	<artifactId>soteria-bean-decorator-weld</artifactId>
-	<packaging>bundle</packaging>
 
 	<name>Soteria SPI : Bean Decorator : Weld</name>
 
@@ -37,13 +36,13 @@
 		<dependency>
 			<groupId>org.jboss.weld</groupId>
 			<artifactId>weld-osgi-bundle</artifactId>
-			<version>4.0.0.Alpha1</version>
+			<version>4.0.0.Alpha2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.soteria</groupId>
 			<artifactId>jakarta.security.enterprise</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -57,7 +56,31 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>4.2.1</version>
 				<extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
 			</plugin>
+            
+            <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.glassfish.soteria.bean.decorator.weld</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 </project>

--- a/test/app-mem-customform/pom.xml
+++ b/test/app-mem-customform/pom.xml
@@ -29,11 +29,11 @@
 	<artifactId>app-mem-customform</artifactId>
 	<packaging>war</packaging>
 
-        <properties>
+	<properties>
             <failOnMissingWebXml>false</failOnMissingWebXml>
         </properties>
 
-        <dependencies>
+	<dependencies>
             <dependency>
                 <groupId>org.glassfish.soteria.test</groupId>
                 <artifactId>common</artifactId>
@@ -46,7 +46,7 @@
             </dependency>
         </dependencies>
 
-        <build>
+	<build>
             <finalName>app-mem-customform</finalName>
         </build>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -156,7 +156,8 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.12.2</version><!--$NO-MVN-MAN-VER$-->
+            <version>1.12.2</version>
+            <!--$NO-MVN-MAN-VER$-->
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* Moved tests to their own profile
* Adjusted Javadoc targets to be compliant with JDK11+
* Made modules plain jar as all other projects with generated manifest
for OSGi

Signed-off-by: arjantijms <arjan.tijms@gmail.com>