### PR TITLE
Fix invocationContext.proceed() is call twice - #254

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -168,7 +168,8 @@ public class RememberMeInterceptor implements Serializable {
             rememberMeIdentityStore.removeLoginToken(rememberMeCookie.getValue());
         }
 
-        invocationContext.proceed();
+        // invocationContext.proceed() will be called at the end of intercept already.
+        // invocationContext.proceed();
     }
     
     private RememberMe getRememberMeFromIntercepted(ELProcessor elProcessor, InvocationContext invocationContext) {


### PR DESCRIPTION
Fix invocationContext.proceed() is call twice - #254 in RememberMeInterceptor.java
Signed-off-by: Loc Ha <haducloc13@gmail.com>