### PR TITLE
Resolves #330 Build the UriBuilder first and call toString() on the resulting URI.

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/controller/AuthenticationController.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/openid/controller/AuthenticationController.java
@@ -124,7 +124,7 @@ public class AuthenticationController {
 
         configuration.getExtraParameters().forEach(authRequest::queryParam);
 
-        String authUrl = authRequest.toString();
+        String authUrl = authRequest.build().toString();
         LOGGER.log(FINEST, "Redirecting for authentication to {0}", authUrl);
         try {
             response.sendRedirect(authUrl);


### PR DESCRIPTION
The UriBuilder API does not specify that a toString() method needs to be implemented or what it should return so some implementations default to returning the class name and instance hash.