### PR TITLE
Fix for #340 - JNDI lookup returns object or throws exception

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/cdi/CdiUtils.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/CdiUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -37,11 +38,10 @@ import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.naming.InitialContext;
-import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 
 public class CdiUtils {
-	
+
     public static <A extends Annotation> Optional<A> getAnnotation(BeanManager beanManager, Annotated annotated, Class<A> annotationType) {
 
         annotated.getAnnotation(annotationType);
@@ -74,13 +74,13 @@ public class CdiUtils {
 
         return empty();
     }
-    
+
     public static void addAnnotatedTypes(BeforeBeanDiscovery beforeBean, BeanManager beanManager, Class<?>... types) {
         for (Class<?> type : types) {
             beforeBean.addAnnotatedType(beanManager.createAnnotatedType(type), "Soteria " + type.getName());
         }
     }
-    
+
     public static <A extends Annotation> Optional<A> getAnnotation(BeanManager beanManager, Class<?> annotatedClass, Class<A> annotationType) {
 
         if (annotatedClass.isAnnotationPresent(annotationType)) {
@@ -107,23 +107,28 @@ public class CdiUtils {
 
         return empty();
     }
-    
-    public static BeanManager getBeanManager() {
-        BeanManager beanManager = jndiLookup("java:comp/BeanManager");
 
-        if (beanManager == null) {
-            // Servlet containers
-            beanManager = jndiLookup("java:comp/env/BeanManager");
+    /**
+     * @return non-null {@link BeanManager}
+     * @throws IllegalStateException if it wasn't possible to find the CDI BeanManager.
+     */
+    public static BeanManager getBeanManager() throws IllegalStateException {
+        try {
+            return jndiLookup("java:comp/BeanManager","java:comp/env/BeanManager");
+        } catch (NamingException e) {
+            throw new IllegalStateException("The CDI Bean Manager is not available.", e);
         }
-
-        return beanManager;
     }
-    
-    // 
+
+    /**
+     * @param type the required bean type the reference must have
+     * @param qualifiers the required qualifiers the reference must have
+     * @return a bean reference adhering to the required type and qualifiers
+     */
     public static <T> T getBeanReference(Class<T> type, Annotation... qualifiers) {
         return type.cast(getBeanReferenceByType(getBeanManager(), type, qualifiers));
     }
-    
+
     /**
      * @param beanManager the bean manager
      * @param type the required bean type the reference must have
@@ -145,17 +150,17 @@ public class CdiUtils {
 
         return beanReference;
     }
-    
+
     @SuppressWarnings("unchecked")
     private static <T> T getContextualReference(Class<T> type, BeanManager beanManager, Set<Bean<?>> beans) {
-        
+
         Object beanReference = null;
-        
+
         Bean<?> bean = beanManager.resolve(beans);
         if (bean != null) {
             beanReference = beanManager.getReference(bean, type, beanManager.createCreationalContext(bean));
         }
-        
+
         return (T) beanReference;
     }
 
@@ -172,19 +177,19 @@ public class CdiUtils {
 
         return result;
     }
-    
+
     public static ELProcessor getELProcessor(ELProcessor elProcessor) {
         if (elProcessor != null) {
             return elProcessor;
         }
-        
+
         return getELProcessor();
     }
-    
+
     public static ELProcessor getELProcessor() {
         ELProcessor elProcessor = new ELProcessor();
         elProcessor.getELManager().addELResolver(getBeanManager().getELResolver());
-        
+
         return elProcessor;
     }
 
@@ -192,27 +197,40 @@ public class CdiUtils {
         Set<Bean<?>> beans = beanManager.getBeans(type, new AnyAnnotationLiteral());
         if (!isEmpty(beans)) {
             return beans;
-        } 
-        
+        }
+
         if (optional) {
             return emptySet();
-        } 
-        
+        }
+
         throw new IllegalStateException("Could not find beans for Type=" + type);
     }
 
-    @SuppressWarnings("unchecked")
-    public static <T> T jndiLookup(String name) {
+    /**
+     * Tries provided names, first found non-null object is returned.
+     *
+     * @param <T> expected type
+     * @param names list of JNDI names to try.
+     * @return non-null object
+     * @throws NamingException if all lookups ended with an exception or null values.
+     */
+    public static <T> T jndiLookup(String... names) throws NamingException {
         InitialContext context = null;
         try {
             context = new InitialContext();
-            return (T) context.lookup(name);
-        } catch (NamingException e) {
-            if (is(e, NameNotFoundException.class)) {
-                return null;
-            } else {
-                throw new IllegalStateException(e);
+            NamingException exceptionCollector = new NamingException(String.join(", ", names));
+            for (String name : names) {
+                try {
+                    @SuppressWarnings("unchecked")
+                    T found = (T) context.lookup(name);
+                    if (found != null) {
+                        return found;
+                    }
+                } catch (NamingException e) {
+                    exceptionCollector.addSuppressed(e);
+                }
             }
+            throw exceptionCollector;
         } finally {
             close(context);
         }
@@ -227,7 +245,7 @@ public class CdiUtils {
             throw new IllegalStateException(e);
         }
     }
-    
+
     public static <T extends Throwable> boolean is(Throwable exception, Class<T> type) {
         Throwable unwrappedException = exception;
 

--- a/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
+++ b/impl/src/main/java/org/glassfish/soteria/servlet/SamRegistrationInstaller.java
@@ -74,7 +74,6 @@ public class SamRegistrationInstaller implements ServletContainerInitializer, Se
             // and calling CDI.current() will throw an exception. It's no use to continue then.
             // TODO: Do we need to find out *why* the default module does not have CDI initialized?
             logger.log(FINEST, "CDI not available for app context id: " + Jaspic.getAppContextID(ctx), e);
-
             return;
         }
 


### PR DESCRIPTION
- Both usages in Soteria require an object, null results in exceptions
- BeanManager can have two possible JNDI names, we don't care which, we need an instance.
- The lookup now allows to provide a list contexts which are processed in order.
- IllegalStateException was replaced by NamingException. It's message simply reports used unsuccessful names.
- BeanManager is used in functions etc, so the exception may be wrapped by IllegalStateException again. Null cannot be provided (old impl then resulted in NullpointerException).
- DataSource can still result in the same exception if it is not available, but new impl simplified the code.

Signed-off-by: David Matějček <david.matejcek@omnifish.ee>