### PR TITLE
Do not require a caller principal obtained from EJB to be assignable from CallerPrincipal

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
@@ -514,7 +514,8 @@ public class SubjectParser {
                 break;
         }
 
-        if (CallerPrincipal.class.isAssignableFrom(principal.getClass())) {
+        // do not require a principal from EJBContext to be assignable from CallerPrincipal
+        if (isEjb || CallerPrincipal.class.isAssignableFrom(principal.getClass())) {
             return principal;
         }
 


### PR DESCRIPTION
Cherry-pick from https://github.com/eclipse-ee4j/soteria/pull/344