### PR TITLE
Exclude static import for realm

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -66,6 +66,7 @@
                             !org.apache.tomee.catalina,!org.apache.tomee.catalina,!weblogic.security.jacc.simpleprovider,
                             !weblogic.security.jacc,!org.glassfish.deployment.common,!org.glassfish.internal.api,
                             !org.jboss.as.security.service,!org.apache.geronimo.security.jacc.mappingprovider,
+                            !org.apache.catalina.realm,
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
Import added by class.forName checking, but should not be a static import.