### PR TITLE
Fixes #254 - do not call ctx.proceed() if it was already called in RememberMe interceptor

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -58,55 +58,56 @@ import jakarta.servlet.http.HttpServletResponse;
 public class RememberMeInterceptor implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    
+
     @Inject
     private BeanManager beanManager;
-    
+
     @Inject
     @Intercepted
     private Bean<?> interceptedBean;
 
     @AroundInvoke
     public Object intercept(InvocationContext invocationContext) throws Exception {
-        
+
         // If intercepting HttpAuthenticationMechanism#validateRequest
         if (isImplementationOf(invocationContext.getMethod(), validateRequestMethod)) {
             return validateRequest(
-                invocationContext, 
-                getParam(invocationContext, 0),  
+                invocationContext,
+                getParam(invocationContext, 0),
                 getParam(invocationContext, 1),
                 getParam(invocationContext, 2));
         }
-        
+
         // If intercepting HttpAuthenticationMechanism#cleanSubject
         if (isImplementationOf(invocationContext.getMethod(), cleanSubjectMethod)) {
             cleanSubject(
-                invocationContext, 
-                getParam(invocationContext, 0),  
+                invocationContext,
+                getParam(invocationContext, 0),
                 getParam(invocationContext, 1),
-                getParam(invocationContext, 2));
+                    getParam(invocationContext, 2));
+            return null;
         }
-        
+
         return invocationContext.proceed();
     }
-    
+
     private AuthenticationStatus validateRequest(InvocationContext invocationContext, HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws Exception {
-        
+
         RememberMeIdentityStore rememberMeIdentityStore = CdiUtils.getBeanReference(RememberMeIdentityStore.class);
         RememberMe rememberMeAnnotation = getRememberMeFromIntercepted(getElProcessor(invocationContext, httpMessageContext), invocationContext);
-        
+
         Cookie rememberMeCookie = getCookie(request, rememberMeAnnotation.cookieName());
-        
+
         if (rememberMeCookie != null) {
-            
+
             // There's a remember me cookie, see if we can use it to authenticate
-            
+
             CredentialValidationResult result = rememberMeIdentityStore.validate(
                 new RememberMeCredential(rememberMeCookie.getValue())
             );
-            
+
             if (result.getStatus() == VALID) {
-                // The remember me store contained an authenticated identity associated with 
+                // The remember me store contained an authenticated identity associated with
                 // the given token, use it to authenticate with the container
                 return httpMessageContext.notifyContainerAboutLogin(
                     result.getCallerPrincipal(), result.getCallerGroups());
@@ -116,67 +117,67 @@ public class RememberMeInterceptor implements Serializable {
                 removeCookie(request, response, rememberMeAnnotation.cookieName());
             }
         }
-        
+
         // Try to authenticate with the next interceptor or actual authentication mechanism
         AuthenticationStatus authstatus = (AuthenticationStatus) invocationContext.proceed();
-        
+
         if (authstatus == AuthenticationStatus.SUCCESS && httpMessageContext.getCallerPrincipal() != null) {
-            
+
             // Authentication succeeded;
             // Check if remember me is wanted by the caller and if so
             // store the authenticated identity in the remember me store
             // and send a cookie with a token that can be used
             // to retrieve this stored identity later
-            
+
             Boolean isRememberMe = true;
             if (rememberMeAnnotation instanceof RememberMeAnnotationLiteral) { // tmp
                 isRememberMe = ((RememberMeAnnotationLiteral)rememberMeAnnotation).isRememberMe();
             }
-            
+
             if (isRememberMe) {
                 String token = rememberMeIdentityStore.generateLoginToken(
                     toCallerPrincipal(httpMessageContext.getCallerPrincipal()),
                     httpMessageContext.getGroups()
                 );
-                
+
                 saveCookie(
-                    request, response, 
-                    rememberMeAnnotation.cookieName(), 
-                    token, 
+                    request, response,
+                    rememberMeAnnotation.cookieName(),
+                    token,
                     rememberMeAnnotation.cookieMaxAgeSeconds(),
                     rememberMeAnnotation.cookieSecureOnly(),
                     rememberMeAnnotation.cookieHttpOnly());
             }
         }
-        
+
         return authstatus;
     }
-    
+
     private void cleanSubject(InvocationContext invocationContext, HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws Exception {
-    
+
         RememberMeIdentityStore rememberMeIdentityStore = CdiUtils.getBeanReference(RememberMeIdentityStore.class); // TODO ADD CHECKS
         RememberMe rememberMeAnnotation = getRememberMeFromIntercepted(getElProcessor(invocationContext, httpMessageContext), invocationContext);
-        
+
         Cookie rememberMeCookie = getCookie(request, rememberMeAnnotation.cookieName());
-        
+
         if (rememberMeCookie != null) {
-            
+
             // There's a remember me cookie, remove the cookie
             removeCookie(request, response, rememberMeAnnotation.cookieName());
-            
+
             // And remove the token (and with it the authenticated identity) from the store
             rememberMeIdentityStore.removeLoginToken(rememberMeCookie.getValue());
         }
 
         invocationContext.proceed();
     }
-    
+
     private RememberMe getRememberMeFromIntercepted(ELProcessor elProcessor, InvocationContext invocationContext) {
         Optional<RememberMe> optionalRememberMe = getAnnotation(beanManager, interceptedBean.getBeanClass(), RememberMe.class);
         if (optionalRememberMe.isPresent()) {
             return RememberMeAnnotationLiteral.eval(optionalRememberMe.get(), elProcessor);
         }
-        
+
         @SuppressWarnings("unchecked")
         Set<Annotation> bindings = (Set<Annotation>) invocationContext.getContextData().get("org.jboss.weld.interceptor.bindings");
         if (bindings != null) {
@@ -184,23 +185,23 @@ public class RememberMeInterceptor implements Serializable {
                     .filter(annotation -> annotation.annotationType().equals(RememberMe.class))
                     .findAny()
                     .map(annotation -> RememberMe.class.cast(annotation));
-            
+
             if (optionalRememberMe.isPresent()) {
                 return RememberMeAnnotationLiteral.eval(optionalRememberMe.get(), elProcessor);
             }
         }
-        
+
         throw new IllegalStateException("@RememberMe not present on " + interceptedBean.getBeanClass());
     }
-    
+
     private ELProcessor getElProcessor(InvocationContext invocationContext, HttpMessageContext httpMessageContext) {
         ELProcessor elProcessor = new ELProcessor();
-        
+
         elProcessor.getELManager().addELResolver(beanManager.getELResolver());
         elProcessor.defineBean("self", invocationContext.getTarget());
         elProcessor.defineBean("httpMessageContext", httpMessageContext);
-        
+
         return elProcessor;
     }
- 
+
 }


### PR DESCRIPTION
This is an alternative fix to https://github.com/eclipse-ee4j/soteria/pull/295 which has been open for a while and doesn't seem to be getting anywhere.

If this is merged, it fixes #254 and then https://github.com/eclipse-ee4j/soteria/pull/295 can be closed.