### PR TITLE
Fixes #254 - do not call ctx.proceed() if it was already called in RememberMe interceptor

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
+++ b/impl/src/main/java/org/glassfish/soteria/cdi/RememberMeInterceptor.java
@@ -84,6 +84,7 @@ public class RememberMeInterceptor implements Serializable {
                     getParam(invocationContext, 0),
                     getParam(invocationContext, 1),
                     getParam(invocationContext, 2));
+            return null;
         }
 
         return invocationContext.proceed();


### PR DESCRIPTION
This is an alternative fix to https://github.com/eclipse-ee4j/soteria/pull/295 which has been open for a while and doesn't seem to be getting anywhere.

If this is merged, it fixes #254 and then https://github.com/eclipse-ee4j/soteria/pull/295 can be closed.