### PR TITLE
fix: Call build before toString when building logout URL.

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/OpenIdAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/OpenIdAuthenticationMechanism.java
@@ -474,7 +474,7 @@ public class OpenIdAuthenticationMechanism implements HttpAuthenticationMechanis
                 logoutURI.queryParam(POST_LOGOUT_REDIRECT_URI, logout.buildRedirectURI(request));
             }
 
-            redirect(response, logoutURI.toString());
+            redirect(response, logoutURI.build().toString());
         } else if (!isEmpty(logout.getRedirectURI())) {
             redirect(response, logout.buildRedirectURI(request));
         } else {


### PR DESCRIPTION
There is an existing issue for this: #367