### PR TITLE
Replace PrincipalImpl with UserNameAndPassword in SubjectParser

### DIFF
--- a/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
+++ b/impl/src/main/java/org/glassfish/soteria/authorization/spi/impl/SubjectParser.java
@@ -411,7 +411,7 @@ public class SubjectParser {
      */
     private Principal getVendorCallerPrincipal(Principal principal, boolean isEjb) {
         switch (principal.getClass().getName()) {
-            case "org.glassfish.security.common.PrincipalImpl": // GlassFish/Payara
+            case "org.glassfish.security.common.UserNameAndPassword": // GlassFish/Payara
                 return getAuthenticatedPrincipal(principal, "ANONYMOUS", isEjb);
             case "weblogic.security.principal.WLSUserImpl": // WebLogic
                 return getAuthenticatedPrincipal(principal, "<anonymous>", isEjb);


### PR DESCRIPTION
# Description 
PrincipalImpl does not exist anymore


# Context
When using `SecurityContext.authenticate(HttpServletRequest request, HttpServletResponse response, AuthenticationParameters parameters);`

`SecurityContext.getCallerPrincipal()` returns null due to PrincipalImpl no longer existing  in both Payara and Glassfish when looking for the specific vendor caller principal:

```
for (Principal principal : principals) {
            // Do some checks to determine it from vendor specific data
            Principal vendorCallerPrincipal = getVendorCallerPrincipal(principal, false);
            if (vendorCallerPrincipal != null) {
                return vendorCallerPrincipal;
            }
        }
```

cc @arjantijms 