### PR TITLE
Initial JWT implementation

### DIFF
--- a/impl/src/main/java/module-info.java
+++ b/impl/src/main/java/module-info.java
@@ -34,6 +34,9 @@ module org.glassfish.soteria {
     exports org.glassfish.soteria.mechanisms.openid.domain;
     exports org.glassfish.soteria.rest;
     exports org.glassfish.soteria.servlet;
+    exports org.glassfish.soteria.identitystores.jwt;
+    exports org.glassfish.soteria.identitystores.jwt.keystore;
+    exports org.glassfish.soteria.identitystores.jwt.token;
 
     provides jakarta.ws.rs.container.DynamicFeature with org.glassfish.soteria.rest.RestAccessControlFeature;
 

--- a/impl/src/main/java/org/glassfish/soteria/TokenCredential.java
+++ b/impl/src/main/java/org/glassfish/soteria/TokenCredential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -13,21 +13,20 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package org.glassfish.soteria.identitystores;
+package org.glassfish.soteria;
 
-public class IdentityStoreRuntimeException extends IdentityStoreException {
+import jakarta.security.enterprise.credential.Credential;
 
-  private static final long serialVersionUID = 1L;
+public class TokenCredential implements Credential {
 
-  public IdentityStoreRuntimeException(String message, Throwable cause) {
-    super(message,cause);
-  }
+    public final String token;
 
-  public IdentityStoreRuntimeException(Throwable cause) {
-    super(cause);
-  }
+    public TokenCredential(String signedJWT) {
+        this.token = signedJWT;
+    }
 
-  public IdentityStoreRuntimeException(String message) {
-    super(message);
-  }
+    public String getSignedJWT() {
+        return token;
+    }
+
 }

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreConfigurationException.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreConfigurationException.java
@@ -13,10 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package org.glassfish.soteria.identitystores;
 
 public class IdentityStoreConfigurationException extends IdentityStoreException {
+
+  private static final long serialVersionUID = 1L;
 
   public IdentityStoreConfigurationException(String message, Throwable cause) {
     super(message,cause);

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreException.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/IdentityStoreException.java
@@ -13,10 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package org.glassfish.soteria.identitystores;
 
 public class IdentityStoreException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
 
   public IdentityStoreException(String message, Throwable cause) {
     super(message,cause);

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/JWTIdentityStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/JWTIdentityStore.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores;
+
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.glassfish.soteria.TokenCredential;
+import org.glassfish.soteria.identitystores.jwt.JWTConfiguration;
+import org.glassfish.soteria.identitystores.jwt.JsonWebTokenImpl;
+import org.glassfish.soteria.identitystores.jwt.keystore.PrivateKeyStore;
+import org.glassfish.soteria.identitystores.jwt.keystore.PublicKeyStore;
+import org.glassfish.soteria.identitystores.jwt.token.JwtTokenParser;
+
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+import static java.util.logging.Level.INFO;
+
+/**
+ * @author Arjan Tijms
+ */
+public class JWTIdentityStore implements IdentityStore {
+
+    private static final Logger LOGGER = Logger.getLogger(JWTIdentityStore.class.getName());
+
+    private final JWTConfiguration jwtConfiguration;
+
+    private final PublicKeyStore publicKeyStore;
+    private final PrivateKeyStore privateKeyStore;
+
+    public JWTIdentityStore(JWTConfiguration jwtConfiguration) {
+        this.jwtConfiguration = jwtConfiguration;
+
+        publicKeyStore = new PublicKeyStore(jwtConfiguration.keyCacheTTL(), jwtConfiguration.publicKey(), jwtConfiguration.publicKeyLocation());
+        privateKeyStore = new PrivateKeyStore(jwtConfiguration.keyCacheTTL(), jwtConfiguration.decryptKeyLocation());
+    }
+
+    public CredentialValidationResult validate(TokenCredential signedJWTCredential) {
+        JwtTokenParser jwtTokenParser =
+                new JwtTokenParser(
+                    jwtConfiguration.enabledNamespace(),
+                    jwtConfiguration.customNamespace(),
+                    jwtConfiguration.disableTypeVerification());
+
+        try {
+            JsonWebTokenImpl jsonWebToken =
+                jwtTokenParser.parse(
+                    signedJWTCredential.getSignedJWT(),
+                    jwtConfiguration.isEncryptionRequired(),
+                    publicKeyStore,
+                    jwtConfiguration.acceptedIssuer(),
+                    privateKeyStore,
+                    jwtConfiguration.tokenAge(),
+                    jwtConfiguration.clockSkew(),
+                    jwtConfiguration.keyAlgorithm());
+
+            Set<String> recipientsOfThisJWT = jsonWebToken.claimSet("aud");
+
+            Boolean recipientInAudience =
+                jwtConfiguration.allowedAudience().isEmpty() ||
+                jwtConfiguration.allowedAudience()
+                                .stream()
+                                .anyMatch(a -> recipientsOfThisJWT != null && recipientsOfThisJWT.contains(a));
+
+            if (!recipientInAudience) {
+                throw new Exception("The supplied audience " + recipientsOfThisJWT + " is not a part of target audience.");
+            }
+
+            Set<String> groups = new HashSet<>();
+            Collection<String> groupClaims = jsonWebToken.claimSet("groups");
+            if (groupClaims != null) {
+                groups.addAll(groupClaims);
+            }
+
+            return new CredentialValidationResult(jsonWebToken, groups);
+
+        } catch (Exception e) {
+            LOGGER.log(INFO, "Exception parsing JWT token.", e);
+        }
+
+        return INVALID_RESULT;
+    }
+
+
+
+}

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/JWTConfiguration.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/JWTConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores.jwt;
+
+import java.time.Duration;
+import java.util.List;
+
+public record JWTConfiguration(
+
+    String configJwtTokenHeader,
+    String configJwtTokenCookie,
+
+    String acceptedIssuer,
+    List<String> allowedAudience,
+    String publicKey,
+    String publicKeyLocation,
+    String decryptKeyLocation,
+    String keyAlgorithm,
+    long tokenAge,
+    long clockSkew,
+    Duration keyCacheTTL,
+
+
+    boolean enabledNamespace,
+    String customNamespace,
+    boolean disableTypeVerification,
+    boolean isEncryptionRequired) {
+
+    public static final String CONFIG_TOKEN_HEADER_AUTHORIZATION = "Authorization";
+    public static final String CONFIG_TOKEN_HEADER_COOKIE = "Cookie";
+
+}

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/JsonWebTokenImpl.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/JsonWebTokenImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores.jwt;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import jakarta.security.enterprise.CallerPrincipal;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+/**
+ *
+ * @author Arjan Tijms
+ */
+public class JsonWebTokenImpl extends CallerPrincipal {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, JsonValue> claims;
+
+    public JsonWebTokenImpl(String callerName, Map<String, JsonValue> claims) {
+        super(callerName);
+        this.claims = claims;
+    }
+
+    public Map<String, JsonValue> claims() {
+        return claims;
+    }
+
+    public JsonValue claimValue(String claimName) {
+        return claims.get(claimName);
+    }
+
+    public Set<String> claimSet(String claimName) {
+        JsonValue claimValue =  claims.get(claimName);
+        if (claimValue == null) {
+            return null;
+        }
+
+        if (claimValue instanceof JsonString jsonString) {
+            return Collections.singleton((jsonString.getString()));
+        }
+
+        if (claimValue instanceof JsonArray jsonArray) {
+            return new HashSet<>(jsonArray.getValuesAs(JsonString.class))
+                    .stream().map(t -> t.getString())
+                    .collect(toSet());
+        }
+
+        throw new IllegalStateException("");
+
+    }
+
+    public Set<String> getClaimNames() {
+        if (claims.isEmpty()) {
+            return null;
+        }
+
+        return claims.keySet();
+    }
+
+
+}

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/KeyParser.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/KeyParser.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores.jwt.keystore;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * This class focused on the raw "materials" (turning strings into cryptographic keys)
+ */
+public class KeyParser {
+
+    private static final Logger LOGGER = Logger.getLogger(KeyParser.class.getName());
+
+    private static final String RSA_ALGORITHM = "RSA";
+    private static final String EC_ALGORITHM = "EC";
+
+    enum KeyFormat {
+        PEM,
+        JSON_JWK_OR_JWKS,
+        BASE64_JSON_JWK_OR_JWKS,
+        BASE64_DER,
+        UNKNOWN
+    }
+
+    public PublicKey createPublicKey(String key, String keyId) {
+        try {
+            return switch (detectKeyFormat(key)) {
+                case PEM, BASE64_DER -> createPublicKeyFromPem(key);
+                case JSON_JWK_OR_JWKS, BASE64_JSON_JWK_OR_JWKS -> createPublicKeyFromJWKS(key, keyId);
+                default -> throw new DeploymentException("Unrecognized public key format");
+            };
+        } catch (DeploymentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DeploymentException(e);
+        }
+    }
+
+    public PrivateKey createPrivateKey(String key, String keyId) {
+        try {
+            return switch (detectKeyFormat(key)) {
+                case PEM, BASE64_DER -> createPrivateKeyFromPem(key);
+                case JSON_JWK_OR_JWKS, BASE64_JSON_JWK_OR_JWKS -> createPrivateKeyFromJWKS(key, keyId);
+                default -> throw new DeploymentException("Unrecognized private key format");
+            };
+        } catch (DeploymentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DeploymentException(e);
+        }
+    }
+
+    private PublicKey createPublicKeyFromPem(String key) throws Exception {
+       X509EncodedKeySpec publicKeySpec =
+           new X509EncodedKeySpec(
+               Base64.getDecoder()
+                     .decode(trimPem(key)));
+
+       try {
+           return KeyFactory.getInstance(RSA_ALGORITHM)
+                            .generatePublic(publicKeySpec);
+       } catch (InvalidKeySpecException invalidKeySpecException) {
+           // Try ECDSA
+           LOGGER.finer("Caught InvalidKeySpecException creating public key from PEM using RSA algorithm, " +
+                   "attempting again using ECDSA");
+
+           return KeyFactory.getInstance(EC_ALGORITHM)
+                            .generatePublic(publicKeySpec);
+       }
+   }
+
+   private PublicKey createPublicKeyFromJWKS(String jwksValue, String keyId) throws Exception {
+       JsonObject jwk = parseJwk(jwksValue, keyId);
+       String kty = getKty(jwk);
+
+       var decoder = Base64.getUrlDecoder();
+
+       if (kty.equals("RSA")) {
+           return KeyFactory.getInstance(RSA_ALGORITHM)
+                            .generatePublic(
+                                new RSAPublicKeySpec(
+                                    new BigInteger(1, decoder.decode(jwk.getString("n"))),
+                                    new BigInteger(1, decoder.decode(jwk.getString("e")))));
+
+       } else if (kty.equals("EC")) {
+           // Get parameters
+           AlgorithmParameters parameters = AlgorithmParameters.getInstance(EC_ALGORITHM);
+
+           // Check CRV
+           String crv = jwk.getString("crv", null);
+           if (!"P-256".equals(crv)) {
+               throw new DeploymentException("Could not get EC key from JWKS: crv does not equal P-256");
+           }
+
+           parameters.init(new ECGenParameterSpec("secp256r1"));
+
+           return KeyFactory.getInstance(EC_ALGORITHM)
+                   .generatePublic(
+                       new ECPublicKeySpec(
+                           new ECPoint(
+                               new BigInteger(1, decoder.decode(jwk.getString("x"))),
+                               new BigInteger(1, decoder.decode(jwk.getString("y")))),
+                           parameters.getParameterSpec(ECParameterSpec.class)));
+       } else {
+           throw new DeploymentException("Could not determine key type - JWKS kty field does not equal RSA or EC");
+       }
+    }
+
+    private PrivateKey createPrivateKeyFromPem(String key) throws Exception {
+        return
+            KeyFactory.getInstance(RSA_ALGORITHM)
+                      .generatePrivate(
+                          new PKCS8EncodedKeySpec(
+                              Base64.getDecoder()
+                                    .decode(trimPem(key))));
+    }
+
+    private PrivateKey createPrivateKeyFromJWKS(String jwksValue, String keyId) throws Exception {
+        JsonObject jwk = parseJwk(jwksValue, keyId);
+
+        if (getKty(jwk).equals(RSA_ALGORITHM)) {
+            var decoder = Base64.getUrlDecoder();
+
+            return KeyFactory.getInstance(RSA_ALGORITHM)
+                             .generatePrivate(
+                                 new RSAPrivateKeySpec(
+                                     new BigInteger(1, decoder.decode(jwk.getString("n"))),
+                                     new BigInteger(1, decoder.decode(jwk.getString("d")))));
+        } else {
+            throw new DeploymentException("Could not determine key type - JWKS kty field does not equal RSA");
+        }
+    }
+
+    private static KeyFormat detectKeyFormat(String key) {
+        if (key == null || key.isBlank()) {
+            return KeyFormat.UNKNOWN;
+        }
+
+        String trimmed = key.trim();
+
+        // PEM armor
+        if (trimmed.startsWith("-----BEGIN ") && trimmed.contains("-----END ")) {
+            return KeyFormat.PEM;
+        }
+
+        // Plain JSON JWK/JWKS
+        if (looksLikeJwkJson(trimmed)) {
+            return KeyFormat.JSON_JWK_OR_JWKS;
+        }
+
+        // Base64-decoded JSON JWK/JWKS
+        try {
+            byte[] decoded = Base64.getDecoder().decode(trimmed);
+            String decodedText = new String(decoded, java.nio.charset.StandardCharsets.UTF_8).trim();
+
+            if (looksLikeJwkJson(decodedText)) {
+                return KeyFormat.BASE64_JSON_JWK_OR_JWKS;
+            }
+
+            // If it decoded but is not JSON, assume it may be DER-encoded key material
+            return KeyFormat.BASE64_DER;
+        } catch (IllegalArgumentException e) {
+            return KeyFormat.UNKNOWN;
+        }
+    }
+
+    private static boolean looksLikeJwkJson(String s) {
+        if (!s.startsWith("{")) {
+            return false;
+        }
+
+        try (JsonReader reader = Json.createReader(new StringReader(s))) {
+            JsonObject obj = reader.readObject();
+            return obj.containsKey("keys") || obj.containsKey("kty");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static JsonObject parseJwk(String jwksValue, String keyId) throws IOException {
+        JsonObject jwks = parseJwks(jwksValue);
+        JsonArray keys = jwks.getJsonArray("keys");
+
+        return keys != null ? findJwk(keys, keyId) : jwks;
+    }
+
+    private static JsonObject parseJwks(String jwksValue) throws IOException {
+        JsonObject jwks;
+        try (JsonReader reader = Json.createReader(new StringReader(jwksValue))) {
+            jwks = reader.readObject();
+        } catch (Exception ex) {
+            byte[] jwksDecodedValue = Base64.getDecoder().decode(jwksValue);
+            try (InputStream jwksStream = new ByteArrayInputStream(jwksDecodedValue);
+                    JsonReader reader = Json.createReader(jwksStream)) {
+                jwks = reader.readObject();
+            }
+        }
+
+        return jwks;
+    }
+
+    private static JsonObject findJwk(JsonArray keys, String keyID) {
+        if (Objects.isNull(keyID) && keys.size() > 0) {
+            return keys.getJsonObject(0);
+        }
+
+        for (JsonValue value : keys) {
+            JsonObject jwk = value.asJsonObject();
+            if (Objects.equals(keyID, jwk.getString("kid", null))) {
+                return jwk;
+            }
+        }
+
+        throw new IllegalStateException("No matching JWK for KeyID.");
+    }
+
+    private static String getKty(JsonObject jwk) {
+        String kty = jwk.getString("kty", null);
+        if (kty == null) {
+            throw new DeploymentException("Could not determine key type - kty field not present");
+        }
+
+        return kty;
+    }
+
+    private static String trimPem(String key) {
+        if (key == null) {
+            return null;
+        }
+
+        return
+            key.lines()
+               .map(String::trim)
+               .filter(line -> !line.isEmpty())
+               .filter(line -> !(line.startsWith("-----BEGIN ") && line.endsWith("-----")))
+               .filter(line -> !(line.startsWith("-----END ") && line.endsWith("-----")))
+               .collect(joining());
+    }
+
+}

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/PrivateKeyStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/PrivateKeyStore.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores.jwt.keystore;
+
+import java.security.PrivateKey;
+import java.time.Duration;
+
+public class PrivateKeyStore {
+
+    private final RawKeyLoader keyLoader;
+    private final KeyParser keyParser;
+
+    public PrivateKeyStore(Duration defaultCacheTTL, String keyLocation) {
+        this.keyLoader = new RawKeyLoader(keyLocation, defaultCacheTTL);
+        this.keyParser = new KeyParser();
+    }
+
+    public PrivateKey getPrivateKey(String keyId) {
+        String rawKey = keyLoader.readRawPublicKey();
+        if (rawKey == null) {
+            throw new IllegalStateException("No PublicKey found");
+        }
+
+        return keyParser.createPrivateKey(rawKey, keyId);
+    }
+
+}

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/PublicKeyStore.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/PublicKeyStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores.jwt.keystore;
+
+import java.security.PublicKey;
+import java.time.Duration;
+
+public class PublicKeyStore {
+
+    private final RawKeyLoader keyLoader;
+    private final KeyParser keyParser;
+    private final String key;
+
+    public PublicKeyStore(Duration defaultCacheTTL, String key, String keyLocation) {
+        this.keyLoader = new RawKeyLoader(keyLocation, defaultCacheTTL);
+        this.keyParser = new KeyParser();
+        this.key = key;
+    }
+
+    public PublicKey getPublicKey(String keyID) {
+        String rawKey = key;
+        if (rawKey.isEmpty()) {
+            rawKey = keyLoader.readRawPublicKey();
+            if (rawKey == null) {
+                throw new IllegalStateException("No PublicKey found");
+            }
+        }
+
+        return keyParser.createPublicKey(rawKey, keyID);
+    }
+
+}

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/RawKeyLoader.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/keystore/RawKeyLoader.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores.jwt.keystore;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import org.glassfish.soteria.identitystores.jwt.keystore.Cache.CacheItem;
+
+import static java.lang.Character.isWhitespace;
+import static java.lang.Long.parseLong;
+import static java.lang.System.lineSeparator;
+import static java.lang.Thread.currentThread;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+
+public class RawKeyLoader {
+
+    private static final Logger LOGGER = Logger.getLogger(RawKeyLoader.class.getName());
+
+    private final String keyLocation;
+    private final Cache<String> cache;
+
+    public RawKeyLoader(String keyLocation, Duration defaultCacheTTL) {
+        this.keyLocation = keyLocation;
+        cache = new Cache<String>(defaultCacheTTL);
+    }
+
+    public String readRawPublicKey() {
+        return cache.computeIfAbsentOrExpired(() -> readKeyFromLocation(keyLocation));
+    }
+
+    private CacheItem<String> readKeyFromLocation(String keyLocation) {
+        // Try if keyLocation refers to the classpath, e.g. "publicKey.pem"
+        URL keyURL = currentThread().getContextClassLoader().getResource(keyLocation);
+
+        if (keyURL == null) {
+            try {
+                keyURL = new URL(keyLocation);
+            } catch (MalformedURLException ex) {
+                keyURL = null;
+            }
+        }
+        if (keyURL == null) {
+            return new CacheItem<>(null, null);
+        }
+
+        try {
+            return readKeyFromURL(keyURL);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to read key.", ex);
+        }
+    }
+
+    private CacheItem<String> readKeyFromURL(URL keyURL) throws IOException {
+        URLConnection connection = keyURL.openConnection();
+
+        Charset charset = resolveCharset(connection);
+        Duration cacheTTL = resolveCacheTTL(connection);
+
+        try (InputStream inputStream = connection.getInputStream();
+             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, charset))) {
+
+            return CacheItem.of(reader.lines().collect(joining(lineSeparator())), cacheTTL);
+        }
+    }
+
+    private Charset resolveCharset(URLConnection connection) {
+        String charsetName = getCharacterEncoding(connection.getContentType());
+        if (charsetName == null) {
+            return UTF_8;
+        }
+
+        try {
+            if (!Charset.isSupported(charsetName)) {
+                LOGGER.warning("Charset " + charsetName + " for remote key not supported, using UTF-8 instead");
+                return UTF_8;
+            }
+
+            return Charset.forName(charsetName);
+        } catch (IllegalCharsetNameException ex) {
+            LOGGER.severe(
+                "Illegal charset name " + ex.getCharsetName() +
+                " for remote key, using UTF-8 instead. Cause: " + ex.getMessage());
+            return UTF_8;
+        }
+    }
+
+    private Duration resolveCacheTTL(URLConnection connection) {
+        return connection.getHeaderFields().entrySet().stream()
+                .filter(entry -> entry.getKey() != null)
+                .filter(entry -> "Cache-Control".equalsIgnoreCase(entry.getKey().trim()))
+                .flatMap(entry -> entry.getValue().stream())
+                .flatMap(value -> Stream.of(value.split(",")))
+                .map(String::trim)
+                .map(this::parseMaxAgeDirective)
+                .filter(Objects::nonNull)
+                .min(Duration::compareTo)
+                .orElse(null);
+    }
+
+    private Duration parseMaxAgeDirective(String directive) {
+        if (!directive.startsWith("max-age")) {
+            return null;
+        }
+
+        String[] keyValue = directive.split("=", 2);
+        if (keyValue.length != 2) {
+            return null;
+        }
+
+        try {
+            return Duration.ofSeconds(parseLong(keyValue[1].trim()));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static String getCharacterEncoding(String type) {
+        if (type == null || type.isEmpty()) {
+            return null;
+        }
+
+        int index = type.indexOf(';');
+        while (index != -1) {
+            int len = type.length();
+            index++;
+
+            while (index < len && isWhitespace(type.charAt(index))) {
+                index++;
+            }
+
+            int eq = type.indexOf('=', index);
+            if (eq == -1) {
+                break;
+            }
+
+            String name = type.substring(index, eq).trim();
+            if ("charset".equalsIgnoreCase(name)) {
+                int valueStart = eq + 1;
+                int nextParam = type.indexOf(';', valueStart);
+                String value = (nextParam != -1 ? type.substring(valueStart, nextParam) : type.substring(valueStart)).trim();
+
+                if (value.isEmpty()) {
+                    return null;
+                }
+
+                if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+                    value = value.substring(1, value.length() - 1).trim();
+                }
+
+                return value.isEmpty() ? null : value;
+            }
+
+            index = type.indexOf(';', eq);
+        }
+
+        return null;
+    }
+
+}
+
+final class Cache<T> {
+
+    private final Duration defaultTTL;
+    private volatile State<T> state = State.uninitialized();
+
+    public Cache(Duration defaultTTL) {
+        this.defaultTTL = defaultTTL;
+    }
+
+    public <E extends Exception> T computeIfAbsentOrExpired(ThrowingItemSupplier<? extends T, E> supplier) throws E {
+        State<T> current = state;
+        long now = System.nanoTime();
+
+        if (current.isExpired(now)) {
+            refresh(now, supplier);
+            current = state;
+        }
+
+        return current.value;
+    }
+
+    private <E extends Exception> void refresh(long now, ThrowingItemSupplier<? extends T, E> supplier) throws E {
+        synchronized (this) {
+            if (!state.isExpired(now)) {
+                return;
+            }
+
+            CacheItem<? extends T> item = supplier.get();
+            Duration ttl = item.ttl() != null ? item.ttl() : defaultTTL;
+
+            state = new State<>(item.payload(), System.nanoTime() + ttl.toNanos(), true);
+        }
+    }
+
+    @FunctionalInterface
+    public interface ThrowingItemSupplier<T, E extends Exception> {
+        CacheItem<T> get() throws E;
+    }
+
+    /**
+     * ttl == null means: use the cache's default TTL.
+     */
+    public static record CacheItem<T>(T payload, Duration ttl) {
+        public static <T> CacheItem<T> of(T payload, Duration ttl) {
+            return new CacheItem<>(payload, ttl);
+        }
+
+        public static <T> CacheItem<T> withDefaultTTL(T payload) {
+            return new CacheItem<>(payload, null);
+        }
+    }
+
+    private static final class State<T> {
+        private final T value;
+        private final long expiresAtNanos;
+        private final boolean initialized;
+
+        private State(T value, long expiresAtNanos, boolean initialized) {
+            this.value = value;
+            this.expiresAtNanos = expiresAtNanos;
+            this.initialized = initialized;
+        }
+
+        private static <T> State<T> uninitialized() {
+            return new State<>(null, 0L, false);
+        }
+
+        private boolean isExpired(long nowNanos) {
+            return !initialized || nowNanos >= expiresAtNanos;
+        }
+    }
+}

--- a/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/token/JwtTokenParser.java
+++ b/impl/src/main/java/org/glassfish/soteria/identitystores/jwt/token/JwtTokenParser.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.identitystores.jwt.token;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.SignedJWT;
+
+import jakarta.json.Json;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+
+import java.io.StringReader;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.glassfish.soteria.identitystores.jwt.JsonWebTokenImpl;
+import org.glassfish.soteria.identitystores.jwt.keystore.PrivateKeyStore;
+import org.glassfish.soteria.identitystores.jwt.keystore.PublicKeyStore;
+
+import static com.nimbusds.jose.JWEAlgorithm.RSA_OAEP;
+import static com.nimbusds.jose.JWEAlgorithm.RSA_OAEP_256;
+import static com.nimbusds.jose.JWSAlgorithm.ES256;
+import static com.nimbusds.jose.JWSAlgorithm.RS256;
+import static org.glassfish.soteria.identitystores.jwt.token.JwtTokenParser.JwtType.detectType;
+
+public class JwtTokenParser {
+
+    private static String exp = "exp";
+    private static String iat = "iat";
+    private static String iss = "iss";
+    private static String jti = "jti";
+    private static String preferred_username = "preferred_username";
+    private static String raw_token = "raw_token";
+    private static String sub = "sub";
+    private static String upn = "upn";
+
+    private static final List<String> REQUIRED_CLAIMS = List.of(iss, sub, exp, iat, jti);
+
+    private final boolean enableNamespacedClaims;
+    private final String customNamespace;
+
+    public enum JwtType {
+        SIGNED, ENCRYPTED, INVALID;
+
+        public static JwtType detectType(String token) {
+            if (token == null) {
+                return INVALID;
+            }
+
+            return switch (token.length() - token.replace(".", "").length()) {
+            case 2 -> SIGNED; // 3 parts = 2 dots
+            case 4 -> ENCRYPTED; // 5 parts = 4 dots
+            default -> INVALID;
+            };
+        }
+    }
+
+    public JwtTokenParser() {
+        this(false, null, false);
+    }
+
+    public JwtTokenParser(boolean enableNamespacedClaims, String customNamespace, boolean disableTypeVerification) {
+        this.enableNamespacedClaims = enableNamespacedClaims;
+        this.customNamespace = customNamespace;
+    }
+
+    public JsonWebTokenImpl parse(String bearerToken, boolean encryptionRequired, PublicKeyStore publicKeyStore, String acceptedIssuer,
+            PrivateKeyStore privateKeyStore, long tokenAge, long clockSkew, String keyAlgorithm) {
+        try {
+            return switch (detectType(bearerToken)) {
+                case SIGNED -> {
+                    if (encryptionRequired) {
+                        throw new IllegalStateException("JWT expected to be encrypted (JWE), but a signed token (JWS) was provided.");
+                    }
+                    yield processSignedToken(bearerToken, SignedJWT.parse(bearerToken), publicKeyStore, acceptedIssuer, tokenAge, clockSkew);
+                }
+                case ENCRYPTED ->
+                    processEncryptedToken(bearerToken, EncryptedJWT.parse(bearerToken), publicKeyStore, privateKeyStore, acceptedIssuer, tokenAge, clockSkew, keyAlgorithm);
+                case INVALID ->
+                    throw new IllegalStateException("Invalid JWT token");
+            };
+        } catch (ParseException | JOSEException e) {
+            throw new IllegalStateException("Failed to parse or decrypt JWT", e);
+        }
+    }
+
+
+    // Handle the signed token
+
+    private JsonWebTokenImpl processSignedToken(String rawToken, SignedJWT signedJWT, PublicKeyStore pubStore, String issuer, long age,
+            long skew) {
+
+        validateSignatureAlgorithm(signedJWT);
+
+        try (JsonReader reader = Json.createReader(new StringReader(signedJWT.getPayload().toString()))) {
+            Map<String, JsonValue> claims = handleNamespacedClaims(new HashMap<>(reader.readObject()));
+            String principal = resolvePrincipal(claims);
+
+            validateClaims(claims, signedJWT, issuer, principal, pubStore.getPublicKey(signedJWT.getHeader().getKeyID()), age, skew);
+
+            // Inject the raw token into the claims map
+            claims.put(raw_token, Json.createValue(rawToken));
+
+            return new JsonWebTokenImpl(principal, claims);
+        }
+    }
+
+
+    // Handle the encryped token
+
+    private JsonWebTokenImpl processEncryptedToken(String rawToken, EncryptedJWT encryptedJWT, PublicKeyStore pubStore,
+            PrivateKeyStore privStore, String issuer, long age, long skew, String alg)
+            throws JOSEException, ParseException {
+
+        validateEncryptionHeader(encryptedJWT, alg);
+
+        String kid = encryptedJWT.getHeader().getKeyID();
+        encryptedJWT.decrypt(new RSADecrypter(privStore.getPrivateKey(kid)));
+
+        SignedJWT nestedSignedJWT = encryptedJWT.getPayload().toSignedJWT();
+        if (nestedSignedJWT == null) {
+            throw new IllegalStateException("JWE payload is not a valid Signed JWT");
+        }
+
+        return processSignedToken(rawToken, nestedSignedJWT, pubStore, issuer, age, skew);
+    }
+
+    private void validateClaims(Map<String, JsonValue> claims, SignedJWT signedJWT, String expectedIssuer, String principal, PublicKey key,
+            long maxAge, long skew) {
+
+        if (!claims.keySet().containsAll(REQUIRED_CLAIMS)) {
+            throw new IllegalStateException("Missing required MP-JWT claims");
+        }
+
+        if (principal == null) {
+            throw new IllegalStateException("No valid principal found (upn, preferred_username, or sub required)");
+        }
+
+        if (!checkIssuer(claims, expectedIssuer)) {
+            throw new IllegalStateException("Issuer mismatch");
+        }
+
+        long now = Instant.now().getEpochSecond();
+        long expTime = getLongClaim(claims, exp);
+        long iatTime = getLongClaim(claims, iat);
+
+        if (now - skew > expTime || iatTime > expTime) {
+            throw new IllegalStateException("Token has expired");
+        }
+
+        if (maxAge > 0 && (now - skew - iatTime > maxAge)) {
+            throw new IllegalStateException("Token exceeds maximum allowed age");
+        }
+
+        verifySignature(signedJWT, key);
+    }
+
+    private void verifySignature(SignedJWT signedJWT, PublicKey key) {
+        try {
+            boolean verified = signedJWT.getHeader().getAlgorithm().equals(RS256)
+                    ? signedJWT.verify(new RSASSAVerifier((RSAPublicKey) key))
+                    : signedJWT.verify(new ECDSAVerifier((ECPublicKey) key));
+
+            if (!verified) {
+                throw new IllegalStateException("Invalid JWT signature");
+            }
+        } catch (JOSEException e) {
+            throw new IllegalStateException("Cryptographic error during verification", e);
+        }
+    }
+
+    private String resolvePrincipal(Map<String, JsonValue> claims) {
+        return Stream.of(upn, preferred_username, sub)
+                     .map(c -> claims.get(c))
+                     .filter(v -> v instanceof JsonString)
+                     .map(v -> ((JsonString) v).getString())
+                     .findFirst()
+                     .orElse(null);
+    }
+
+    private Map<String, JsonValue> handleNamespacedClaims(Map<String, JsonValue> claims) {
+        if (enableNamespacedClaims || customNamespace == null) {
+            return claims;
+        }
+
+        Map<String, JsonValue> processed = new HashMap<>();
+        claims.forEach((key, value) -> {
+            String newKey = key.startsWith(customNamespace) ? key.substring(customNamespace.length()) : key;
+            processed.put(newKey, value);
+        });
+
+        return processed;
+    }
+
+    @SuppressWarnings("deprecation")
+    private void validateEncryptionHeader(EncryptedJWT jwt, String requiredAlg) {
+        String cty = jwt.getHeader().getContentType();
+        if (!"JWT".equals(cty)) {
+            throw new IllegalStateException("No 'cty' header is set for encrypyted JWE");
+        }
+
+        String alg = jwt.getHeader().getAlgorithm().getName();
+        if (!List.of(RSA_OAEP.getName(), RSA_OAEP_256.getName()).contains(alg)) {
+            throw new IllegalStateException("Unsupported encryption algorithm: " + alg);
+        }
+
+        if (!requiredAlg.isEmpty() && !alg.equals(requiredAlg)) {
+            throw new IllegalStateException("Algorithm " + alg + " does not match required " + requiredAlg);
+        }
+    }
+
+    private void validateSignatureAlgorithm(SignedJWT jwt) {
+        JOSEObjectType type = jwt.getHeader().getType();
+        if (type == null || !type.toString().equals("JWT")) {
+            throw new IllegalStateException("Type of header is not JWT for signed JWE");
+        }
+
+        JWSAlgorithm alg = jwt.getHeader().getAlgorithm();
+        if (!alg.equals(RS256) && !alg.equals(ES256)) {
+            throw new IllegalStateException("Unsupported signing algorithm: " + alg);
+        }
+    }
+
+    private boolean checkIssuer(Map<String, JsonValue> claims, String expected) {
+        return
+            claims.get(iss) instanceof JsonString issClaimString &&
+            issClaimString.getString().equals(expected);
+    }
+
+    private long getLongClaim(Map<String, JsonValue> claims, String claim) {
+        return ((JsonNumber) claims.get(claim)).longValue();
+    }
+}

--- a/impl/src/main/java/org/glassfish/soteria/mechanisms/JWTAuthenticationMechanism.java
+++ b/impl/src/main/java/org/glassfish/soteria/mechanisms/JWTAuthenticationMechanism.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.soteria.mechanisms;
+
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+import org.glassfish.soteria.TokenCredential;
+import org.glassfish.soteria.identitystores.jwt.JWTConfiguration;
+
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.Status.VALID;
+import static org.glassfish.soteria.identitystores.jwt.JWTConfiguration.CONFIG_TOKEN_HEADER_AUTHORIZATION;
+
+/**
+ * This authentication mechanism reads a JWT token from an HTTP header and passes it
+ * to an {@link IdentityStore} for validation.
+ *
+ * @author Arjan Tijms
+ */
+public class JWTAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    private final boolean useHeader;
+    private final String configJwtTokenCookie;
+
+    public JWTAuthenticationMechanism(JWTConfiguration jwtConfiguration) {
+        this.useHeader = CONFIG_TOKEN_HEADER_AUTHORIZATION.equals(jwtConfiguration.configJwtTokenHeader());
+        this.configJwtTokenCookie = jwtConfiguration.configJwtTokenCookie();
+    }
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthenticationException {
+        TokenCredential credential = getCredential(request);
+        if (credential == null) {
+            return httpMessageContext.doNothing();
+        }
+
+        CredentialValidationResult result =
+            CDI.current()
+               .select(IdentityStoreHandler.class)
+               .get()
+               .validate(credential);
+
+        if (result.getStatus() != VALID) {
+            return httpMessageContext.responseUnauthorized();
+        }
+
+        httpMessageContext.getClientSubject()
+                .getPrincipals()
+                .add(result.getCallerPrincipal());
+
+        return httpMessageContext.notifyContainerAboutLogin(result);
+    }
+
+    private TokenCredential getCredential(HttpServletRequest request) {
+        Optional<String> token = Optional.empty();
+        if (useHeader) {
+            String authorizationHeader = request.getHeader("Authorization");
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                token = Optional.of(authorizationHeader.substring("Bearer ".length()));
+            }
+        } else {
+            // use Cookie header
+            String bearerMark = ";" + configJwtTokenCookie + "=";
+            String cookieHeader = request.getHeader("Cookie");
+            if (cookieHeader != null && cookieHeader.startsWith("$Version=") && cookieHeader.contains(bearerMark)) {
+                token = Optional.of(cookieHeader.substring(cookieHeader.indexOf(bearerMark) + bearerMark.length()));
+            }
+        }
+
+        return token.map(t -> createSignedJWTCredential(t))
+                    .orElse(null);
+    }
+
+    private TokenCredential createSignedJWTCredential(String token) {
+        if (token != null && !token.isEmpty()) {
+            return new TokenCredential(token);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Implements JWT in a basic way. Activation not yet done directly.

The current implementation can function as a base for MP JWT, as well as a base for EE JWT. It's the intention to keep the base suitable to support both.

See https://github.com/eclipse-ee4j/soteria/issues/415